### PR TITLE
Fix reservation redirect to payment

### DIFF
--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -134,9 +134,11 @@ export default function ReservationForm(){
   /* ---------- envío ---------- */
   const onSubmit = async data => {
     try{
-      await reservationService.create(data)
-      setToast({open:true,msg:'Reserva creada',severity:'success'})
-      // opcional: redirect...
+      const res = await reservationService.create(data)
+
+      notify('Reserva creada ✅','success')
+
+      navigate(`/payments/${res.id}`,{ replace:true })
     }catch(e){
       if(e.response?.status===409){
         notify('El código ya existe. Intenta de nuevo.','error')


### PR DESCRIPTION
## Summary
- after creating a reservation, redirect to payment wizard using the returned id

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68541d2ee49c832cbfc2b3f0e3606710