### PR TITLE
Make receipt email asynchronous

### DIFF
--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -5,7 +5,7 @@ const base = import.meta.env.VITE_API_BASE_URL || '/api';
 const http = axios.create({
   baseURL: base,
   headers: { 'Content-Type': 'application/json' },
-  timeout: 10000
+  timeout: 30000
 });
 
 export default http;

--- a/kartingrm/src/main/java/com/kartingrm/KartingrmApplication.java
+++ b/kartingrm/src/main/java/com/kartingrm/KartingrmApplication.java
@@ -3,9 +3,11 @@ package com.kartingrm;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class KartingrmApplication {
 
 	public static void main(String[] args) {

--- a/kartingrm/src/main/java/com/kartingrm/service/PaymentService.java
+++ b/kartingrm/src/main/java/com/kartingrm/service/PaymentService.java
@@ -54,8 +54,7 @@ public class PaymentService {
         TransactionSynchronizationManager.registerSynchronization(
                 new TransactionSynchronizationAdapter() {
                     @Override public void afterCommit() {
-                        byte[] pdfBytes = pdf.buildReceipt(r, p);
-                        mail.sendReceipt(r, pdfBytes);
+                        mail.sendReceipt(r, pdf.buildReceipt(r, p));
                     }
                 });
 

--- a/kartingrm/src/main/java/com/kartingrm/service/mail/MailService.java
+++ b/kartingrm/src/main/java/com/kartingrm/service/mail/MailService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mail.javamail.*;
 import org.springframework.stereotype.Service;
+import org.springframework.scheduling.annotation.Async;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class MailService {
 
     private final JavaMailSender sender;
 
+    @Async
     public void sendReceipt(Reservation r, byte[] pdf){
         r.getParticipantsList().stream()
                 .map(Participant::getEmail)


### PR DESCRIPTION
## Summary
- enable async processing in Spring Boot app
- send payment receipts asynchronously
- return receipts quicker by deferring the email
- relax frontend timeout while developing

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68542420d6b0832cbd9348ebac300d43