### PR TITLE
Add monthly report endpoints and table

### DIFF
--- a/kartingrm-frontend/src/App.jsx
+++ b/kartingrm-frontend/src/App.jsx
@@ -17,6 +17,7 @@ const WeeklyRack       = lazy(() => import('./pages/WeeklyRack'))
 const ReservationForm  = lazy(() => import('./pages/ReservationForm'))
 const ReservationsList = lazy(() => import('./pages/ReservationsList'))
 const ReportCharts     = lazy(() => import('./pages/ReportCharts'))
+const ReportTable      = lazy(() => import('./pages/ReportTable'))
 const ClientsCrud      = lazy(() => import('./pages/ClientsCrud'))
 const SessionsCrud     = lazy(() => import('./pages/SessionsCrud'))
 const PaymentPage      = lazy(() => import('./pages/PaymentPage'))
@@ -58,6 +59,7 @@ export default function App() {
             <Route path="/clients" element={<ClientsCrud />} />
             <Route path="/sessions" element={<SessionsCrud />} />
             <Route path="/reports" element={<ReportCharts />} />
+            <Route path="/reports/monthly" element={<ReportTable />} />
             <Route path="/help" element={<Help />} />
             {/* Ruta comodín para 404 */}
             <Route path="*" element={<NotFound />} />

--- a/kartingrm-frontend/src/components/Navbar.jsx
+++ b/kartingrm-frontend/src/components/Navbar.jsx
@@ -17,6 +17,7 @@ export default function Navbar(){
           <Button color="inherit" component={RouterLink} to="/rack">Rack</Button>
           <Button color="inherit" component={RouterLink} to="/reservations">Reservas</Button>
           <Button color="inherit" component={RouterLink} to="/reports">Reportes</Button>
+          <Button color="inherit" component={RouterLink} to="/reports/monthly">Reporte Mensual</Button>
           <Button color="inherit" component={RouterLink} to="/clients">Clientes</Button>
           <Button color="inherit" component={RouterLink} to="/sessions">Sesiones</Button>
           <Button color="inherit" component={RouterLink} to="/tariffs">Tarifas</Button>

--- a/kartingrm-frontend/src/pages/ReportTable.jsx
+++ b/kartingrm-frontend/src/pages/ReportTable.jsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import {
+  Table, TableHead, TableBody, TableRow, TableCell,
+  Paper, Typography, Button, Stack
+} from '@mui/material';
+import reportService from '../services/report.service';
+import dayjs from 'dayjs';
+
+export default function ReportTable() {
+  const from = dayjs().startOf('year').format('YYYY-MM-DD');
+  const to   = dayjs().endOf('year').format('YYYY-MM-DD');
+
+  const [rateData, setRateData]   = useState([]);
+  const [groupData, setGroupData] = useState([]);
+
+  const load = async () => {
+    const [r1, r2] = await Promise.all([
+      reportService.byRateMonthly(from, to),
+      reportService.byGroupMonthly(from, to)
+    ]);
+    setRateData(r1.data);
+    setGroupData(r2.data);
+  };
+
+  const months = Array.from(new Set(rateData.map(d => d.month)))
+    .sort((a,b)=> dayjs(a,'MMMM').month() - dayjs(b,'MMMM').month());
+
+  const buildMatrix = (data, keyField) => {
+    const keys = Array.from(new Set(data.map(d=>d[keyField])));
+    return keys.map(k => ({
+      key: k,
+      counts: months.map(m => {
+        const row = data.find(d => d.month===m && d[keyField]===k);
+        return row?.total ?? 0;
+      }),
+      total: data.filter(d=>d[keyField]===k).reduce((s,d)=>s+d.total,0)
+    }));
+  };
+
+  const rateMatrix  = buildMatrix(rateData, 'rate');
+  const groupMatrix = buildMatrix(groupData,'range');
+
+  return (
+    <Paper sx={{ p:3, maxWidth:800, mx:'auto' }}>
+      <Stack spacing={2}>
+        <Button variant="contained" onClick={load}>Cargar reporte mensual</Button>
+
+        <Typography variant="h6">Ingresos por Tarifa</Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Tarifa</TableCell>
+              {months.map(m => <TableCell key={m}>{m}</TableCell>)}
+              <TableCell>Total</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rateMatrix.map(r => (
+              <TableRow key={r.key}>
+                <TableCell>{r.key}</TableCell>
+                {r.counts.map((c,i)=>
+                  <TableCell key={i}>{c.toLocaleString()}</TableCell>
+                )}
+                <TableCell><strong>{r.total.toLocaleString()}</strong></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        <Typography variant="h6">Ingresos por Grupo</Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Grupo</TableCell>
+              {months.map(m => <TableCell key={m}>{m}</TableCell>)}
+              <TableCell>Total</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {groupMatrix.map(g => (
+              <TableRow key={g.key}>
+                <TableCell>{g.key}</TableCell>
+                {g.counts.map((c,i)=>
+                  <TableCell key={i}>{c.toLocaleString()}</TableCell>
+                )}
+                <TableCell><strong>{g.total.toLocaleString()}</strong></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Stack>
+    </Paper>
+  );
+}

--- a/kartingrm-frontend/src/services/report.service.js
+++ b/kartingrm-frontend/src/services/report.service.js
@@ -1,4 +1,6 @@
 import http from '../http-common'
 const byRate  = (from,to) => http.get('/reports/by-rate',  {params:{from,to}})
 const byGroup = (from,to) => http.get('/reports/by-group', {params:{from,to}})
-export default { byRate, byGroup }
+const byRateMonthly  = (from,to) => http.get('/reports/by-rate/monthly',  { params:{ from, to } })
+const byGroupMonthly = (from,to) => http.get('/reports/by-group/monthly', { params:{ from, to } })
+export default { byRate, byGroup, byRateMonthly, byGroupMonthly }

--- a/kartingrm/src/main/java/com/kartingrm/controller/ReportController.java
+++ b/kartingrm/src/main/java/com/kartingrm/controller/ReportController.java
@@ -1,7 +1,9 @@
 package com.kartingrm.controller;
 
 import com.kartingrm.dto.IncomeByGroupDTO;
+import com.kartingrm.dto.IncomeByGroupMonthlyDTO;
 import com.kartingrm.dto.IncomeByRateDTO;
+import com.kartingrm.dto.IncomeByRateMonthlyDTO;
 import com.kartingrm.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -35,6 +37,20 @@ public class ReportController {
             @RequestParam LocalDate from,
             @RequestParam LocalDate to){
         return reports.ingresosPorGrupo(from, to);
+    }
+
+    @GetMapping("/by-rate/monthly")
+    public List<IncomeByRateMonthlyDTO> byRateMonthly(
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to){
+        return reports.ingresosPorTarifaMensual(from, to);
+    }
+
+    @GetMapping("/by-group/monthly")
+    public List<IncomeByGroupMonthlyDTO> byGroupMonthly(
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to){
+        return reports.ingresosPorGrupoMensual(from, to);
     }
 
     @GetMapping("/by-rate/csv")

--- a/kartingrm/src/main/java/com/kartingrm/dto/IncomeByGroupMonthlyDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/IncomeByGroupMonthlyDTO.java
@@ -1,0 +1,7 @@
+package com.kartingrm.dto;
+
+public record IncomeByGroupMonthlyDTO(
+    String month,
+    String range,
+    Double total
+) {}

--- a/kartingrm/src/main/java/com/kartingrm/dto/IncomeByRateMonthlyDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/IncomeByRateMonthlyDTO.java
@@ -1,0 +1,9 @@
+package com.kartingrm.dto;
+
+import com.kartingrm.entity.RateType;
+
+public record IncomeByRateMonthlyDTO(
+    String month,
+    RateType rate,
+    Double total
+) {}

--- a/kartingrm/src/main/java/com/kartingrm/service/ReportService.java
+++ b/kartingrm/src/main/java/com/kartingrm/service/ReportService.java
@@ -1,7 +1,9 @@
 package com.kartingrm.service;
 
 import com.kartingrm.dto.IncomeByGroupDTO;
+import com.kartingrm.dto.IncomeByGroupMonthlyDTO;
 import com.kartingrm.dto.IncomeByRateDTO;
+import com.kartingrm.dto.IncomeByRateMonthlyDTO;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Service;
 
@@ -46,6 +48,49 @@ public class ReportService {
                         IncomeByGroupDTO.class)
                 .setParameter("f", f.atStartOfDay())
                 .setParameter("t", t.atTime(23, 59, 59))
+                .getResultList();
+    }
+
+    public List<IncomeByRateMonthlyDTO> ingresosPorTarifaMensual(LocalDate from, LocalDate to) {
+        return em.createQuery("""
+      SELECT new com.kartingrm.dto.IncomeByRateMonthlyDTO(
+        FUNCTION('MONTHNAME', p.paymentDate),
+        r.rateType,
+        SUM(p.finalAmountInclVat))
+      FROM Payment p JOIN p.reservation r
+      WHERE p.paymentDate BETWEEN :f AND :t
+      GROUP BY FUNCTION('MONTHNAME', p.paymentDate), r.rateType
+      ORDER BY MONTH(p.paymentDate), r.rateType
+      """, IncomeByRateMonthlyDTO.class)
+                .setParameter("f", from.atStartOfDay())
+                .setParameter("t", to.atTime(23,59,59))
+                .getResultList();
+    }
+
+    public List<IncomeByGroupMonthlyDTO> ingresosPorGrupoMensual(LocalDate from, LocalDate to) {
+        return em.createQuery("""
+      SELECT new com.kartingrm.dto.IncomeByGroupMonthlyDTO(
+        FUNCTION('MONTHNAME', p.paymentDate),
+        CASE
+         WHEN r.participants BETWEEN 1 AND 2 THEN '1-2'
+         WHEN r.participants BETWEEN 3 AND 5 THEN '3-5'
+         WHEN r.participants BETWEEN 6 AND 10 THEN '6-10'
+         ELSE '11-15'
+        END,
+        SUM(p.finalAmountInclVat))
+      FROM Payment p JOIN p.reservation r
+      WHERE p.paymentDate BETWEEN :f AND :t
+      GROUP BY FUNCTION('MONTHNAME', p.paymentDate),
+               CASE
+                 WHEN r.participants BETWEEN 1 AND 2 THEN '1-2'
+                 WHEN r.participants BETWEEN 3 AND 5 THEN '3-5'
+                 WHEN r.participants BETWEEN 6 AND 10 THEN '6-10'
+                 ELSE '11-15'
+               END
+      ORDER BY MONTH(p.paymentDate)
+      """, IncomeByGroupMonthlyDTO.class)
+                .setParameter("f", from.atStartOfDay())
+                .setParameter("t", to.atTime(23,59,59))
                 .getResultList();
     }
 }


### PR DESCRIPTION
## Summary
- support monthly report breakdowns in the backend
- expose monthly report endpoints
- fetch monthly reports from the frontend
- add ReportTable component and navigation

## Testing
- `mvn test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68605200d064832c8d66a2a402508dc1