### PR TITLE
Fix monthly report constructors

### DIFF
--- a/kartingrm-frontend/src/pages/ReportTable.jsx
+++ b/kartingrm-frontend/src/pages/ReportTable.jsx
@@ -6,6 +6,8 @@ import {
 import reportService from '../services/report.service';
 import dayjs from 'dayjs';
 
+const monthName = n => dayjs().month(n - 1).format('MMMM');
+
 export default function ReportTable() {
   const from = dayjs().startOf('year').format('YYYY-MM-DD');
   const to   = dayjs().endOf('year').format('YYYY-MM-DD');
@@ -22,14 +24,15 @@ export default function ReportTable() {
     setGroupData(r2.data);
   };
 
-  const months = Array.from(new Set(rateData.map(d => d.month)))
-    .sort((a,b)=> dayjs(a,'MMMM').month() - dayjs(b,'MMMM').month());
+  const monthNums = Array.from(new Set(rateData.map(d => d.month)))
+    .sort((a,b)=> a - b);
+  const months = monthNums.map(monthName);
 
   const buildMatrix = (data, keyField) => {
     const keys = Array.from(new Set(data.map(d=>d[keyField])));
     return keys.map(k => ({
       key: k,
-      counts: months.map(m => {
+      counts: monthNums.map(m => {
         const row = data.find(d => d.month===m && d[keyField]===k);
         return row?.total ?? 0;
       }),

--- a/kartingrm/src/main/java/com/kartingrm/dto/IncomeByGroupMonthlyDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/IncomeByGroupMonthlyDTO.java
@@ -1,7 +1,7 @@
 package com.kartingrm.dto;
 
 public record IncomeByGroupMonthlyDTO(
-    String month,
-    String range,
+    Integer month,
+    String  range,
     Double total
 ) {}

--- a/kartingrm/src/main/java/com/kartingrm/dto/IncomeByRateMonthlyDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/IncomeByRateMonthlyDTO.java
@@ -3,7 +3,7 @@ package com.kartingrm.dto;
 import com.kartingrm.entity.RateType;
 
 public record IncomeByRateMonthlyDTO(
-    String month,
+    Integer month,
     RateType rate,
     Double total
 ) {}

--- a/kartingrm/src/main/java/com/kartingrm/service/ReportService.java
+++ b/kartingrm/src/main/java/com/kartingrm/service/ReportService.java
@@ -54,12 +54,12 @@ public class ReportService {
     public List<IncomeByRateMonthlyDTO> ingresosPorTarifaMensual(LocalDate from, LocalDate to) {
         return em.createQuery("""
       SELECT new com.kartingrm.dto.IncomeByRateMonthlyDTO(
-        FUNCTION('MONTHNAME', p.paymentDate),
-        r.rateType,
-        SUM(p.finalAmountInclVat))
+         MONTH(p.paymentDate),
+         r.rateType,
+         SUM(p.finalAmountInclVat))
       FROM Payment p JOIN p.reservation r
       WHERE p.paymentDate BETWEEN :f AND :t
-      GROUP BY FUNCTION('MONTHNAME', p.paymentDate), r.rateType
+      GROUP BY MONTH(p.paymentDate), r.rateType
       ORDER BY MONTH(p.paymentDate), r.rateType
       """, IncomeByRateMonthlyDTO.class)
                 .setParameter("f", from.atStartOfDay())
@@ -70,22 +70,22 @@ public class ReportService {
     public List<IncomeByGroupMonthlyDTO> ingresosPorGrupoMensual(LocalDate from, LocalDate to) {
         return em.createQuery("""
       SELECT new com.kartingrm.dto.IncomeByGroupMonthlyDTO(
-        FUNCTION('MONTHNAME', p.paymentDate),
-        CASE
-         WHEN r.participants BETWEEN 1 AND 2 THEN '1-2'
-         WHEN r.participants BETWEEN 3 AND 5 THEN '3-5'
-         WHEN r.participants BETWEEN 6 AND 10 THEN '6-10'
-         ELSE '11-15'
-        END,
-        SUM(p.finalAmountInclVat))
+         MONTH(p.paymentDate),
+         CASE
+           WHEN r.participants BETWEEN 1 AND 2 THEN '1-2'
+           WHEN r.participants BETWEEN 3 AND 5 THEN '3-5'
+           WHEN r.participants BETWEEN 6 AND 10 THEN '6-10'
+           ELSE '11+'
+         END,
+         SUM(p.finalAmountInclVat))
       FROM Payment p JOIN p.reservation r
       WHERE p.paymentDate BETWEEN :f AND :t
-      GROUP BY FUNCTION('MONTHNAME', p.paymentDate),
+      GROUP BY MONTH(p.paymentDate),
                CASE
                  WHEN r.participants BETWEEN 1 AND 2 THEN '1-2'
                  WHEN r.participants BETWEEN 3 AND 5 THEN '3-5'
                  WHEN r.participants BETWEEN 6 AND 10 THEN '6-10'
-                 ELSE '11-15'
+                 ELSE '11+'
                END
       ORDER BY MONTH(p.paymentDate)
       """, IncomeByGroupMonthlyDTO.class)


### PR DESCRIPTION
## Summary
- fix JPQL queries to use MONTH() so Hibernate can infer types
- adjust monthly DTOs to hold numeric month
- map month numbers to names in monthly table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6860b4cda6cc832cb26feacff92cd598