### PR TITLE
Mejora experiencia de usuario

### DIFF
--- a/kartingrm-frontend/src/pages/Help.jsx
+++ b/kartingrm-frontend/src/pages/Help.jsx
@@ -1,14 +1,29 @@
-import { Paper, Typography, Stack } from '@mui/material'
+import { Paper, Typography, Stack, List, ListItem, ListItemText, Divider } from '@mui/material'
 
 export default function Help(){
   return (
-    <Paper sx={{p:3, maxWidth:600, mx:'auto'}}>
+    <Paper sx={{ p: 3, maxWidth: 600, mx: 'auto' }}>
       <Typography variant="h5" gutterBottom>Ayuda</Typography>
-      <Stack spacing={2}>
-        <Typography variant="subtitle1">Preguntas frecuentes</Typography>
-        <Typography>¿Cómo creo una reserva? Use el menú Reservas y presione "Nueva reserva".</Typography>
-        <Typography>¿Dónde consulto reportes? En la sección Reportes del menú principal.</Typography>
-        <Typography>Para soporte adicional contacte al administrador.</Typography>
+      <Stack spacing={3}>
+        <section>
+          <Typography variant="h6">Preguntas frecuentes</Typography>
+          <Typography><b>¿Cómo creo una reserva?</b> Use el menú "Reservas" y presione "Nueva reserva".</Typography>
+          <Typography><b>¿Dónde consulto reportes?</b> En la sección "Reportes" del menú principal.</Typography>
+        </section>
+        <Divider />
+        <section>
+          <Typography variant="h6">Atajos de Teclado</Typography>
+          <List dense>
+            <ListItem>
+              <ListItemText primary="Ir a Inicio:" secondary="Presiona 'g' y luego 'h'" />
+            </ListItem>
+            <ListItem>
+              <ListItemText primary="Ir a Reservas:" secondary="Presiona 'g' y luego 'r'" />
+            </ListItem>
+          </List>
+        </section>
+        <Divider />
+        <Typography>Para soporte adicional, contacte al administrador.</Typography>
       </Stack>
     </Paper>
   )

--- a/kartingrm-frontend/src/pages/NotFound.jsx
+++ b/kartingrm-frontend/src/pages/NotFound.jsx
@@ -1,1 +1,18 @@
-export default () => <h2>404 – Página no encontrada</h2>
+import { Button, Paper, Typography } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+
+export default function NotFound() {
+  return (
+    <Paper sx={{ p: 4, textAlign: 'center' }}>
+      <Typography variant="h4" gutterBottom>
+        404 – Página no encontrada
+      </Typography>
+      <Typography sx={{ mb: 2 }}>
+        Lo sentimos, la página que buscas no existe.
+      </Typography>
+      <Button component={RouterLink} to="/home" variant="contained">
+        Volver al Inicio
+      </Button>
+    </Paper>
+  )
+}

--- a/kartingrm-frontend/src/pages/ReservationsList.jsx
+++ b/kartingrm-frontend/src/pages/ReservationsList.jsx
@@ -3,78 +3,106 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Table, TableHead, TableBody, TableRow, TableCell,
-  Paper, Button, Stack, Typography
+  Paper, Button, Stack, Typography, CircularProgress, Box
 } from '@mui/material'
 import reservationService from '../services/reservation.service'
 import { useNotify } from '../hooks/useNotify'
+import ConfirmDialog from '../components/ConfirmDialog'
 
 export default function ReservationsList() {
   const [list, setList] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [confirm, setConfirm] = useState({ open: false, id: null })
   const navigate = useNavigate()
   const notify = useNotify()
 
   /* carga con AbortController */
   useEffect(() => {
     const controller = new AbortController()
+    setLoading(true)
+    reservationService.list({ signal: controller.signal })
+      .then(r => setList(r.data))
+      .catch(err => {
+        if (!controller.signal.aborted) console.error(err)
+      })
+      .finally(() => setLoading(false))
 
-    const load = () =>
-      reservationService.list({ signal: controller.signal })
-        .then(r => setList(r.data))
-        .catch(err => {
-          if (!controller.signal.aborted) console.error(err)
-        })
-
-    load()
     return () => controller.abort()
   }, [])
 
-  const reload = () =>
-    reservationService.list().then(r => setList(r.data))
+  const reload = () => {
+    setLoading(true)
+    reservationService.list()
+      .then(r => setList(r.data))
+      .finally(() => setLoading(false))
+  }
 
-  const cancel = id =>
-    reservationService.cancel(id).then(reload)
-      .catch(err => notify(err.response?.data?.message || err.message,'error'))
+  const cancel = id => {
+    reservationService.cancel(id)
+      .then(() => {
+        reload()
+        notify('Reserva cancelada', 'success')
+      })
+      .catch(err => notify(err.response?.data?.message || err.message, 'error'))
+      .finally(() => setConfirm({ open: false, id: null }))
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
 
   return (
-    <Paper sx={{ p:2 }}>
-      <Stack direction="row" justifyContent="space-between" sx={{ mb:2 }}>
-        <Typography variant="h6">Reservas</Typography>
-        <Button variant="contained"
-          onClick={()=>navigate('/reservations/new')}>
-          Nueva reserva
-        </Button>
-      </Stack>
+    <>
+      <Paper sx={{ p:2 }}>
+        <Stack direction="row" justifyContent="space-between" sx={{ mb:2 }}>
+          <Typography variant="h6">Reservas</Typography>
+          <Button variant="contained"
+            onClick={()=>navigate('/reservations/new')}>
+            Nueva reserva
+          </Button>
+        </Stack>
 
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            {['Código','Cliente','Fecha','Hora','#','Tarifa','Estado',''].map(h=>
-              <TableCell key={h}>{h}</TableCell>)}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {list.map(r => (
-            <TableRow key={r.id}>
-              <TableCell>{r.reservationCode}</TableCell>
-              <TableCell>{r.client.fullName}</TableCell>
-              <TableCell sx={{ display:{ xs:'none', md:'table-cell' } }}>
-                {r.session.sessionDate}
-              </TableCell>
-              <TableCell>{`${r.session.startTime}-${r.session.endTime}`}</TableCell>
-              <TableCell>{r.participants}</TableCell>
-              <TableCell>{r.rateType}</TableCell>
-              <TableCell>{r.status}</TableCell>
-              <TableCell>
-                {r.status === 'PENDING' &&
-                  <Button color="error" size="small"
-                    onClick={() => cancel(r.id)}>
-                    Cancelar
-                  </Button>}
-              </TableCell>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              {['Código','Cliente','Fecha','Hora','#','Tarifa','Estado',''].map(h=>
+                <TableCell key={h}>{h}</TableCell>)}
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Paper>
+          </TableHead>
+          <TableBody>
+            {list.map(r => (
+              <TableRow key={r.id}>
+                <TableCell>{r.reservationCode}</TableCell>
+                <TableCell>{r.client.fullName}</TableCell>
+                <TableCell sx={{ display:{ xs:'none', md:'table-cell' } }}>
+                  {r.session.sessionDate}
+                </TableCell>
+                <TableCell>{`${r.session.startTime}-${r.session.endTime}`}</TableCell>
+                <TableCell>{r.participants}</TableCell>
+                <TableCell>{r.rateType}</TableCell>
+                <TableCell>{r.status}</TableCell>
+                <TableCell>
+                  {r.status === 'PENDING' &&
+                    <Button color="error" size="small"
+                      onClick={() => setConfirm({ open: true, id: r.id })}>
+                      Cancelar
+                    </Button>}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+      <ConfirmDialog
+        open={confirm.open}
+        msg="¿Estás seguro de que quieres cancelar esta reserva?"
+        onClose={() => setConfirm({ open: false, id: null })}
+        onConfirm={() => cancel(confirm.id)}
+      />
+    </>
   )
 }

--- a/kartingrm-frontend/src/pages/WeeklyRack.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRack.jsx
@@ -8,7 +8,8 @@ import sessionService from '../services/session.service'
 import { format, addDays, startOfWeek } from 'date-fns'
 import { useNavigate } from 'react-router-dom'
 
-const DOW = ['MONDAY','TUESDAY','WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY']
+const DOW_EN = ['MONDAY','TUESDAY','WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY']
+const DOW_ES = ['LUNES','MARTES','MIÉRCOLES','JUEVES','VIERNES','SÁBADO','DOMINGO']
 
 export default function WeeklyRack({ onCellClickAdmin }) {
   const [rack, setRack] = useState({})          // nunca null
@@ -75,7 +76,7 @@ export default function WeeklyRack({ onCellClickAdmin }) {
         <TableHead>
           <TableRow>
             <TableCell sx={{ fontWeight:'bold' }}>Hora</TableCell>
-            {DOW.map(d=>(
+            {DOW_ES.map(d=>(
               <TableCell key={d} sx={{ fontWeight:'bold', textAlign:'center' }}>
                 {d.slice(0,3)}
               </TableCell>
@@ -90,17 +91,17 @@ export default function WeeklyRack({ onCellClickAdmin }) {
               <TableRow key={range}>
                 <TableCell sx={{ fontWeight:500 }}>{range}</TableCell>
 
-                {DOW.map(d=>{
-                  const ses = rack?.[d]?.find(s=>s.startTime === start)
+                {DOW_EN.map((dayKey, index) => {
+                  const ses = rack?.[dayKey]?.find(s=>s.startTime === start)
 
-                  if (!ses) return <TableCell key={d+range}></TableCell>
+                  if (!ses) return <TableCell key={DOW_ES[index] + range}></TableCell>
 
                   const pct     = ses.participantsCount / ses.capacity
                   const isFull  = pct === 1
                   const label   = `${ses.participantsCount}/${ses.capacity}`
                                   
                   return (
-                    <TableCell key={d+range} sx={{ p:0 }}>
+                    <TableCell key={DOW_ES[index] + range} sx={{ p:0 }}>
                       <Tooltip title={`Reservados ${label}`}>
                         <Box
                           sx={{


### PR DESCRIPTION
## Summary
- mostrar carga y confirmar cancelación en reservas
- traducir días de la semana en vista semanal
- mejorar la página 404 con enlace a inicio
- ampliar ayuda con FAQs y atajos de teclado

## Testing
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686606a1f290832c8611e617e579b600