### PR TITLE
Implement capacity checks and error interception

### DIFF
--- a/kartingrm-frontend/src/hooks/useNotify.jsx
+++ b/kartingrm-frontend/src/hooks/useNotify.jsx
@@ -5,14 +5,16 @@ export const NotifyContext = createContext()
 export const useNotify = ()=> useContext(NotifyContext)
 
 export function NotifyProvider({children}){
-  const [snack,setSnack]=useState({open:false,msg:'',severity:'info'})
+  const [snack,setSnack]=useState(null)
   return (
-    <NotifyContext.Provider value={(msg,severity='info')=>setSnack({open:true,msg,severity})}>
+    <NotifyContext.Provider value={(msg,severity='info')=>setSnack({msg,severity})}>
       {children}
-      <Snackbar open={snack.open}
-                autoHideDuration={4000}
-                onClose={()=>setSnack(v=>({...v,open:false}))}>
-        <Alert severity={snack.severity}>{snack.msg}</Alert>
+      <Snackbar
+         key={snack?.msg}
+         open={!!snack}
+         autoHideDuration={4000}
+         onClose={()=>setSnack(null)}>
+        <Alert severity={snack?.severity}>{snack?.msg}</Alert>
       </Snackbar>
     </NotifyContext.Provider>
   )

--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -8,4 +8,24 @@ const http = axios.create({
   timeout: 30000
 });
 
+/* -------- INTERCEPTOR GLOBAL DE ERRORES -------- */
+http.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response?.data?.code) {
+      /* Mapea códigos → mensajes amigables */
+      const map = {
+        CAPACITY_EXCEEDED : 'La sesión ya está completa ❌',
+        SESSION_OVERLAP   : 'Ese horario ya está ocupado ⏰',
+        DUPLICATE_CODE    : 'Código de reserva duplicado',
+        BAD_REQUEST       : err.response.data.message
+      };
+      const msg = map[err.response.data.code] || err.response.data.message;
+      /* Lanza evento global capturado por ErrorBoundary */
+      window.dispatchEvent(new CustomEvent('httpError',{ detail: msg }));
+    }
+    return Promise.reject(err);
+  }
+);
+
 export default http;

--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -134,6 +134,16 @@ export default function ReservationForm(){
   /* ---------- envío ---------- */
   const onSubmit = async data => {
     try{
+      /* ---- VALIDAR AFORO ---- */
+      const { sessionDate, startTime, endTime, participantsList } = data
+      const { data: week } = await sessionService.weekly(sessionDate, sessionDate)
+      const slot = Object.values(week).flat()
+                    .find(s => s.startTime===startTime && s.endTime===endTime)
+      if (slot && slot.participantsCount + participantsList.length > slot.capacity){
+        notify('La sesión ya está completa ❌','error')
+        return
+      }
+
       const res = await reservationService.create(data)
 
       notify('Reserva creada ✅','success')

--- a/kartingrm-frontend/src/pages/WeeklyRack.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRack.jsx
@@ -97,7 +97,7 @@ export default function WeeklyRack({ onCellClickAdmin }) {
                   if (!ses) return <TableCell key={DOW_ES[index] + range}></TableCell>
 
                   const pct     = ses.participantsCount / ses.capacity
-                  const isFull  = pct === 1
+                  const isFull  = ses.participantsCount >= ses.capacity
                   const label   = `${ses.participantsCount}/${ses.capacity}`
                                   
                   return (
@@ -110,7 +110,9 @@ export default function WeeklyRack({ onCellClickAdmin }) {
                             py: .5,
                             cursor: isFull ? 'not-allowed':'pointer',
                             textAlign:'center',
-                            '&:hover': { opacity: isFull ? 1 : .8 }
+                            backgroundColor: isFull ? '#ffcdd2' : '#e8f5e9',
+                            opacity: isFull ? 0.6 : 1,
+                            '&:hover': { opacity: isFull ? 0.6 : .8 }
                           }}
                           onClick={()=>!isFull && handleCellClick(ses)}
                         >

--- a/kartingrm-frontend/src/pages/WeeklyRackAdmin.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRackAdmin.jsx
@@ -12,13 +12,19 @@ export default function WeeklyRackAdmin(){
   const open = (date,start,end) =>
     setDlg({open:true,date,start,end,cap:15})
 
-  const save = ()=>{
-    sessionSvc.create({
-      sessionDate:dlg.date,
-      startTime:dlg.start,
-      endTime:dlg.end,
-      capacity:dlg.cap
-    }).then(()=>{ setDlg({...dlg,open:false}); navigate(0) })
+  const save = async ()=>{
+    try{
+      await sessionSvc.create({
+        sessionDate:dlg.date,
+        startTime:dlg.start,
+        endTime:dlg.end,
+        capacity:dlg.cap
+      })
+      setDlg({...dlg,open:false});
+      navigate(0)
+    }catch(e){
+      /* Mensaje vendrá del interceptor – no cerrar diálogo */
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- show normalized API error messages from axios interceptor
- disable click on full sessions, highlight them in rack view
- validate session capacity before creating reservation
- keep admin dialog open when session creation fails
- allow sequential notifications

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_686759d752a4832ca85b0eea448e6ddd