### PR TITLE
Fix date formatting and select options

### DIFF
--- a/kartingrm-frontend/src/pages/ReportTable.jsx
+++ b/kartingrm-frontend/src/pages/ReportTable.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   Table, TableHead, TableBody, TableRow, TableCell,
   Paper, Typography, Button, Stack

--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -5,7 +5,6 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import dayjs from 'dayjs'
-import { nanoid } from 'nanoid'
 import { isWeekend } from 'date-fns'
 import {
   TextField, Button, Stack, Paper, Typography,
@@ -20,6 +19,9 @@ import clientService      from '../services/client.service'
 import sessionService     from '../services/session.service'
 import tariffSvc          from '../services/tariff.service'
 import { computePrice, buildTariffMaps } from '../helpers'
+
+const RATE_TYPES = ['LAP_10','LAP_15','LAP_20']
+const fmt = d => dayjs(d).format('YYYY-MM-DD')
 
 /* ---------------- esquema ---------------- */
 const schema = yup.object({
@@ -136,7 +138,7 @@ export default function ReservationForm(){
     try{
       /* ---- VALIDAR AFORO ---- */
       const { sessionDate, startTime, endTime, participantsList } = data
-      const { data: week } = await sessionService.weekly(sessionDate, sessionDate)
+      const { data: week } = await sessionService.weekly(fmt(sessionDate), fmt(sessionDate))
       const slot = Object.values(week).flat()
                     .find(s => s.startTime===startTime && s.endTime===endTime)
       if (slot && slot.participantsCount + participantsList.length > slot.capacity){
@@ -230,12 +232,12 @@ export default function ReservationForm(){
           <Controller name="rateType" control={control}
             render={({ field }) => (
               <TextField {...field} select label="Tipo de reserva"
+                value={field.value || ''}
                 error={!!errors.rateType}
                 helperText={errors.rateType?.message}>
-                {tariffs.map(t => (
-                  <MenuItem key={t.rate} value={t.rate}>
-                    {t.rate}&nbsp;–&nbsp;{t.minutes}&nbsp;min&nbsp;(${t.price})
-                  </MenuItem>
+                <MenuItem value="">Seleccione…</MenuItem>
+                {RATE_TYPES.map(r => (
+                  <MenuItem key={r} value={r}>{r}</MenuItem>
                 ))}
               </TextField>
             )}

--- a/kartingrm-frontend/src/pages/WeeklyRackAdmin.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRackAdmin.jsx
@@ -22,7 +22,7 @@ export default function WeeklyRackAdmin(){
       })
       setDlg({...dlg,open:false});
       navigate(0)
-    }catch(e){
+    }catch{
       /* Mensaje vendrá del interceptor – no cerrar diálogo */
     }
   }

--- a/kartingrm-frontend/src/services/session.service.js
+++ b/kartingrm-frontend/src/services/session.service.js
@@ -1,7 +1,13 @@
 import http from '../http-common'
+import dayjs from 'dayjs'
+
+const fmt = d => dayjs(d).format('YYYY-MM-DD')
 
 const weekly = (from, to, cfg = {}) =>
-  http.get('/sessions/availability', { params:{ from, to }, ...cfg })
+  http.get('/sessions/availability', {
+    params:{ from: fmt(from), to: fmt(to) },
+    ...cfg
+  })
 
 const getAll = (cfg = {})            => http.get('/sessions', cfg)
 const create = (payload, cfg = {})   => http.post('/sessions', payload, cfg).then(r => r.data)


### PR DESCRIPTION
## Summary
- normalize date parameters in `session.service.js`
- ensure `RATE_TYPES` select always has options
- use formatted dates when validating capacity
- fix linter errors in unrelated files

## Testing
- `npm run lint`
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb47c310832c8f5485d2f1c4893b