### PR TITLE
Improve error handling and add rack spinner

### DIFF
--- a/kartingrm-frontend/src/main.jsx
+++ b/kartingrm-frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { NotifyProvider } from './hooks/useNotify'
 import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import './index.css'
+
+const queryClient = new QueryClient()
 
 
 ReactDOM.createRoot(document.getElementById('root')).render(
@@ -12,11 +15,13 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     {/* Captura errores JS en cualquier componente hijo */}
     <ErrorBoundary>
       <NotifyProvider>
-        {/* Proporciona enrutamiento basado en historial de navegador */}
-        <BrowserRouter>
-          {/* Componente raíz de nuestra aplicación */}
-          <App />
-        </BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          {/* Proporciona enrutamiento basado en historial de navegador */}
+          <BrowserRouter>
+            {/* Componente raíz de nuestra aplicación */}
+            <App />
+          </BrowserRouter>
+        </QueryClientProvider>
       </NotifyProvider>
     </ErrorBoundary>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- dispatch friendly error messages via Axios interceptor
- enable React Query provider
- fetch rack data with `useQuery` and show a loading spinner

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868006ddb50832cb9aadb6e4910bdfd