### PR TITLE
Limit reservations to 22:00 closing time

### DIFF
--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -62,6 +62,15 @@ const schema = yup.object({
                         .required('Hora fin obligatoria')
                         .test('is-after','Fin debe ser posterior',
                               function (value){ return !value || value > this.parent.startTime }),
+                        .test('is-before-closing', 'La hora de finalización no puede ser después de las 22:00', function(value) {
+                            if (!value) {
+                                return true;
+                            }
+                            const [hours, minutes] = value.split(":").map(Number);
+                            const selectedTime = hours * 60 + minutes;
+                            // Permite hasta las 22:00 inclusive
+                            return selectedTime <= 22 * 60;
+                        })
   participantsList: yup.array().of(
                       yup.object({
                         fullName: yup.string().required('Nombre obligatorio'),

--- a/kartingrm/src/main/java/com/kartingrm/dto/ReservationRequestDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/ReservationRequestDTO.java
@@ -39,6 +39,11 @@ public record ReservationRequestDTO(
         return true;
     }
 
+    @AssertTrue(message = "La hora de finalización no puede ser después de las 22:00")
+    public boolean isEndTimeValid() {
+        return !endTime.isAfter(LocalTime.of(22, 0));
+    }
+
     /* sub‑record */
     public record ParticipantDTO(
             @NotBlank String fullName,


### PR DESCRIPTION
## Summary
- validate reservation end time on frontend and backend

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68695f6c38ac832c9509b16347f733f6