### PR TITLE
Implement frontend closing time validation

### DIFF
--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -61,7 +61,7 @@ const schema = yup.object({
   endTime         : yup.string()
                         .required('Hora fin obligatoria')
                         .test('is-after','Fin debe ser posterior',
-                              function (value){ return !value || value > this.parent.startTime }),
+                              function (value){ return !value || value > this.parent.startTime })
                         .test('is-before-closing', 'La hora de finalización no puede ser después de las 22:00', function(value) {
                             if (!value) {
                                 return true;
@@ -70,7 +70,7 @@ const schema = yup.object({
                             const selectedTime = hours * 60 + minutes;
                             // Permite hasta las 22:00 inclusive
                             return selectedTime <= 22 * 60;
-                        })
+                        }),
   participantsList: yup.array().of(
                       yup.object({
                         fullName: yup.string().required('Nombre obligatorio'),


### PR DESCRIPTION
## Summary
- validate reservation end time does not exceed closing hour in React form

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686963951160832cb2360f0a18b913b5