### PR TITLE
Fix reservation error handling

### DIFF
--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -203,13 +203,8 @@ export default function ReservationForm({ edit = false }){
       notify(`Reserva ${edit ? 'actualizada' : 'creada'} ✅`,'success')
 
       navigate(`/payments/${res.id}`,{ replace:true })
-    }catch(e){
-      if(e.response?.status===409){
-        notify('El código ya existe. Intenta de nuevo.','error')
-      }else{
-        setToast({open:true,msg:e.response?.data?.message||e.message,severity:'error'})
-        notify(e.response?.data?.message||e.message,'error')
-      }
+    }catch{
+      // No es necesario hacer nada aquí, el interceptor global se encarga.
     }
   }
 


### PR DESCRIPTION
## Summary
- remove local error handler in ReservationForm so global interceptor handles errors

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869951e485c832c9c6e0ad614fc9dc6