### PR TITLE
Fix provider order

### DIFF
--- a/kartingrm-frontend/src/main.jsx
+++ b/kartingrm-frontend/src/main.jsx
@@ -12,9 +12,10 @@ const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    {/* Captura errores JS en cualquier componente hijo */}
-    <ErrorBoundary>
-      <NotifyProvider>
+    {/* 1. Proveedor de notificaciones */}
+    <NotifyProvider>
+      {/* 2. Límite de error (ahora puede usar notificaciones) */}
+      <ErrorBoundary>
         <QueryClientProvider client={queryClient}>
           {/* Proporciona enrutamiento basado en historial de navegador */}
           <BrowserRouter>
@@ -22,7 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <App />
           </BrowserRouter>
         </QueryClientProvider>
-      </NotifyProvider>
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </NotifyProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- adjust `NotifyProvider` position in `main.jsx` so `ErrorBoundary` can show notifications

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6869992c980c832cb7023fa7bb108488