### PR TITLE
Fix validation errors and accessibility labels

### DIFF
--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -11,13 +11,15 @@ const http = axios.create({
 /* -------- INTERCEPTOR GLOBAL DE ERRORES -------- */
 http.interceptors.response.use(null, err => {
   const { code, message } = err.response?.data ?? {};
-  const evt = new CustomEvent('httpError', {
-    detail:
-      code === 'CAPACITY_EXCEEDED' ? 'Capacidad de la sesión superada'
-    : code === 'SESSION_OVERLAP'   ? 'El horario seleccionado ya está ocupado. Por favor, revise el Rack de disponibilidad.'
-    : code === 'DUPLICATE_CODE'    ? 'El código ya existe'
-    : message || 'Error desconocido'
-  });
+
+  const known =
+    code === 'CAPACITY_EXCEEDED' ? 'Capacidad de la sesión superada' :
+    code === 'SESSION_OVERLAP'   ? 'El horario seleccionado ya está ocupado. Por favor, revise el Rack de disponibilidad.' :
+    code === 'DUPLICATE_CODE'    ? 'El código ya existe' :
+    code === 'BAD_REQUEST'       ? message :
+    message                      ? message : 'Error desconocido';
+
+  const evt = new CustomEvent('httpError', { detail: known });
   window.dispatchEvent(evt);
   return Promise.reject(err);
 });

--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -243,10 +243,10 @@ export default function ReservationForm({ edit = false }){
         <Stack spacing={2}>
 
           {/* ---------- cliente ---------- */}
-          <Controller name="clientId" control={control}
-            render={({ field }) => (
-              <TextField {...field} select label="Cliente"
-                error={!!errors.clientId} helperText={errors.clientId?.message}>
+            <Controller name="clientId" control={control}
+              render={({ field }) => (
+                <TextField {...field} id={field.name} select label="Cliente"
+                  error={!!errors.clientId} helperText={errors.clientId?.message}>
                 {clients.map(c =>
                   <MenuItem key={c.id} value={c.id}>{c.fullName}</MenuItem>)}
               </TextField>
@@ -254,20 +254,20 @@ export default function ReservationForm({ edit = false }){
           />
 
           {/* ---------- fecha ---------- */}
-          <Controller name="sessionDate" control={control}
-            render={({ field }) => (
-              <TextField {...field} type="date" label="Fecha"
-                InputLabelProps={{shrink:true}}
+            <Controller name="sessionDate" control={control}
+              render={({ field }) => (
+                <TextField {...field} id={field.name} type="date" label="Fecha"
+                  InputLabelProps={{shrink:true}}
                 error={!!errors.sessionDate}
                 helperText={errors.sessionDate?.message}/>
             )}
           />
 
           {/* ---------- hora inicio ---------- */}
-          <Controller name="startTime" control={control}
-            render={({ field }) => (
-              <TextField {...field} type="time" label="Hora inicio"
-                InputLabelProps={{shrink:true}}
+            <Controller name="startTime" control={control}
+              render={({ field }) => (
+                <TextField {...field} id={field.name} type="time" label="Hora inicio"
+                  InputLabelProps={{shrink:true}}
                 inputProps={{ step:300, min:minStart, max:maxEnd }}
                 error={!!errors.startTime}
                 helperText={errors.startTime?.message}
@@ -279,10 +279,10 @@ export default function ReservationForm({ edit = false }){
           />
 
           {/* ---------- tipo / vueltas (dinámico) ---------- */}
-          <Controller name="rateType" control={control}
-            render={({ field }) => (
-              <TextField {...field} select label="Tipo de reserva"
-                value={field.value || ''}
+            <Controller name="rateType" control={control}
+              render={({ field }) => (
+                <TextField {...field} id={field.name} select label="Tipo de reserva"
+                  value={field.value || ''}
                 error={!!errors.rateType}
                 helperText={errors.rateType?.message}>
                 <MenuItem value="">Seleccione…</MenuItem>
@@ -294,10 +294,10 @@ export default function ReservationForm({ edit = false }){
           />
 
           {/* ---------- hora fin ---------- */}
-          <Controller name="endTime" control={control}
-            render={({ field }) => (
-              <TextField {...field} type="time" label="Hora fin"
-                InputLabelProps={{shrink:true}}
+            <Controller name="endTime" control={control}
+              render={({ field }) => (
+                <TextField {...field} id={field.name} type="time" label="Hora fin"
+                  InputLabelProps={{shrink:true}}
                 inputProps={{ readOnly:true }} disabled
                 error={!!errors.endTime}
                 helperText={errors.endTime?.message}/>


### PR DESCRIPTION
## Summary
- improve Axios error interceptor so BAD_REQUEST messages are shown
- assign `id` to form fields for proper label association

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68699ef75c64832ca6ef280d7a41ac7b