### PR TITLE
Ignore axios cancelation errors

### DIFF
--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -10,6 +10,10 @@ const http = axios.create({
 
 /* -------- INTERCEPTOR GLOBAL DE ERRORES -------- */
 http.interceptors.response.use(null, err => {
+  // 0️⃣  Ignorar cancelaciones explícitas
+  if (err.code === 'ERR_CANCELED' || err.message === 'canceled') {
+    return Promise.reject(err);       //  ←  sin lanzar evento
+  }
   // 1. Información devuelta por el backend (cuando existe)
   const code    = err.response?.data?.code;
   const backend = err.response?.data?.message;


### PR DESCRIPTION
## Summary
- ignore Axios `ERR_CANCELED` errors in the global interceptor

## Testing
- `npm --prefix kartingrm-frontend run lint`
- `mvn -q -f kartingrm/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6869a7f248f8832cb43c4efe6189b0d6