### PR TITLE
Implement tariff preview and SpecialDay logic

### DIFF
--- a/kartingrm/src/main/java/com/kartingrm/controller/TariffLookupController.java
+++ b/kartingrm/src/main/java/com/kartingrm/controller/TariffLookupController.java
@@ -1,0 +1,24 @@
+package com.kartingrm.controller;
+
+import com.kartingrm.dto.TariffLookupDTO;
+import com.kartingrm.entity.RateType;
+import com.kartingrm.service.pricing.TariffService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
+
+@RestController @RequestMapping("/api/tariffs") @RequiredArgsConstructor
+public class TariffLookupController {
+
+    private final TariffService tariff;
+
+    @GetMapping("/preview")
+    public TariffLookupDTO preview(@RequestParam LocalDate date,
+                                   @RequestParam RateType rate){
+        var res = tariff.resolve(date, rate);
+        return new TariffLookupDTO(
+                res.cfg().getPrice(),
+                res.cfg().getMinutes(),
+                res.specialDay());
+    }
+}

--- a/kartingrm/src/main/java/com/kartingrm/controller/advice/RestExceptionHandler.java
+++ b/kartingrm/src/main/java/com/kartingrm/controller/advice/RestExceptionHandler.java
@@ -19,8 +19,10 @@ public class RestExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex){
+        boolean sd = ex.getFieldErrors().stream()
+                .anyMatch(f -> f.getDefaultMessage().contains("SpecialDay"));
         return ResponseEntity.badRequest()
-                .body(new ApiError("BAD_REQUEST",
+                .body(new ApiError(sd ? "SPECIAL_DAY_MISMATCH" : "BAD_REQUEST",
                         ex.getFieldErrors().get(0).getDefaultMessage()));
     }
 

--- a/kartingrm/src/main/java/com/kartingrm/dto/TariffLookupDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/TariffLookupDTO.java
@@ -1,0 +1,8 @@
+package com.kartingrm.dto;
+
+import com.kartingrm.entity.SpecialDay;
+
+public record TariffLookupDTO(
+        double      price,
+        int         minutes,
+        SpecialDay  specialDay) {}

--- a/kartingrm/src/main/java/com/kartingrm/entity/SpecialDay.java
+++ b/kartingrm/src/main/java/com/kartingrm/entity/SpecialDay.java
@@ -1,0 +1,4 @@
+package com.kartingrm.entity;
+
+/** Clasificación del día al calcular tarifa. */
+public enum SpecialDay { REGULAR, WEEKEND, HOLIDAY }

--- a/kartingrm/src/test/java/com/kartingrm/controller/ReservationControllerTest.java
+++ b/kartingrm/src/test/java/com/kartingrm/controller/ReservationControllerTest.java
@@ -52,7 +52,7 @@ class ReservationControllerTest {
                 LocalDate.of(2025,5,17),
                 LocalTime.of(10,0), LocalTime.of(10,30),
                 participants,
-                RateType.LAP_10);
+                null, RateType.LAP_10);
 
         Reservation saved = new Reservation();
         saved.setId(1L);

--- a/kartingrm/src/test/java/com/kartingrm/service/PaymentServiceTest.java
+++ b/kartingrm/src/test/java/com/kartingrm/service/PaymentServiceTest.java
@@ -41,7 +41,7 @@ class PaymentServiceTest {
                 "P1", c.getId(),
                 LocalDate.now().plusDays(1),
                 LocalTime.of(15,0), LocalTime.of(15,30),
-                list, RateType.LAP_10);
+                list, null, RateType.LAP_10);
 
         Reservation r = resSvc.createReservation(dto);
         Payment     p = paySvc.pay(new PaymentRequestDTO(r.getId(), "cash"));

--- a/kartingrm/src/test/java/com/kartingrm/service/ReservationServiceTest.java
+++ b/kartingrm/src/test/java/com/kartingrm/service/ReservationServiceTest.java
@@ -43,7 +43,7 @@ class ReservationServiceTest {
                 "R1", c.getId(),
                 LocalDate.now().plusDays(1),
                 LocalTime.of(15,0), LocalTime.of(15,30),
-                list2, RateType.LAP_10);
+                list2, null, RateType.LAP_10);
 
         Reservation r = svc.createReservation(dto1);
         assertThat(r.getParticipants()).isEqualTo(2);
@@ -57,7 +57,7 @@ class ReservationServiceTest {
                 "R1", c.getId(),
                 r.getSession().getSessionDate(),
                 r.getSession().getStartTime(), r.getSession().getEndTime(),
-                list3, RateType.LAP_10);
+                list3, null, RateType.LAP_10);
 
         Reservation updated = svc.update(r.getId(), dto2);
         assertThat(updated.getParticipants()).isEqualTo(3);
@@ -73,7 +73,7 @@ class ReservationServiceTest {
                 "R2", c.getId(),
                 LocalDate.now().plusDays(1),
                 LocalTime.of(15,0), LocalTime.of(15,30),
-                full, RateType.LAP_10);
+                full, null, RateType.LAP_10);
 
         Reservation r = svc.createReservation(dto1);
 
@@ -84,7 +84,7 @@ class ReservationServiceTest {
                 "R2", c.getId(),
                 r.getSession().getSessionDate(),
                 r.getSession().getStartTime(), r.getSession().getEndTime(),
-                overflow, RateType.LAP_10);
+                overflow, null, RateType.LAP_10);
 
         assertThatThrownBy(() -> svc.update(r.getId(), dto2))
                 .isInstanceOf(IllegalStateException.class)
@@ -98,7 +98,7 @@ class ReservationServiceTest {
                 LocalDate.now().plusDays(2),
                 LocalTime.of(16,0), LocalTime.of(16,30),
                 List.of(new ParticipantDTO("P","p@x.com",false)),
-                RateType.LAP_10);
+                null, RateType.LAP_10);
 
         Reservation r1 = svc.createReservation(dto);
         Reservation r2 = svc.createReservation(dto);

--- a/kartingrm/src/test/java/com/kartingrm/service/pricing/PricingServiceTest.java
+++ b/kartingrm/src/test/java/com/kartingrm/service/pricing/PricingServiceTest.java
@@ -44,7 +44,7 @@ class PricingServiceTest {
         when(clientSvc.getTotalVisitsThisMonth(client)).thenReturn(0);
 
         var participants = List.of(new ParticipantDTO("X","x@x",false));
-        var req = new ReservationRequestDTO("C",1L, LocalDate.now(), LocalTime.NOON, LocalTime.NOON.plusMinutes(30), participants, RateType.LAP_10);
+        var req = new ReservationRequestDTO("C",1L, LocalDate.now(), LocalTime.NOON, LocalTime.NOON.plusMinutes(30), participants, null, RateType.LAP_10);
 
         var res = pricingSvc.calculate(req);
 
@@ -72,7 +72,7 @@ class PricingServiceTest {
                 new ParticipantDTO("B","b@b",false),
                 new ParticipantDTO("C","c@c",false)
         );
-        var req = new ReservationRequestDTO("R",1L, LocalDate.of(2025,5,17), LocalTime.NOON, LocalTime.NOON.plusMinutes(35), parts, RateType.LAP_15);
+        var req = new ReservationRequestDTO("R",1L, LocalDate.of(2025,5,17), LocalTime.NOON, LocalTime.NOON.plusMinutes(35), parts, null, RateType.LAP_15);
 
         var out = pricingSvc.calculate(req);
         // group=10%, freq=20%, finalPrice = 3000*(1-0.1)*(1-0.2)*3 ≈?


### PR DESCRIPTION
## Summary
- classify days with new `SpecialDay` enum
- expose tariff preview endpoint returning day classification
- adjust `TariffService` to return tariff and day info
- update reservation request DTO with optional `specialDay` and validation
- improve validation error codes
- update tests for new constructor signature

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6869bc0084e0832c8ca2fbc4b2c0d611