### PR TITLE
Add tariff preview on reservation form

### DIFF
--- a/kartingrm-frontend/src/hooks/useNotify.jsx
+++ b/kartingrm-frontend/src/hooks/useNotify.jsx
@@ -19,3 +19,17 @@ export function NotifyProvider({children}){
     </NotifyContext.Provider>
   )
 }
+
+/* helper de alto nivel – traduce códigos comunes */
+export function useApiErrorHandler() {
+  const notify = useNotify()
+  return err => {
+    const code = err.response?.data?.code
+    switch (code) {
+      case 'SESSION_OVERLAP':        return notify('Horario ocupado',       'error')
+      case 'CAPACITY_EXCEEDED':      return notify('Capacidad superada',    'error')
+      case 'SPECIAL_DAY_MISMATCH':   return notify('Tarifa especial (WE/HOL). Actualiza.', 'error')
+      default:                       return notify(err.response?.data?.message||err.message,'error')
+    }
+  }
+}

--- a/kartingrm-frontend/src/services/tariff.service.js
+++ b/kartingrm-frontend/src/services/tariff.service.js
@@ -5,4 +5,9 @@ const list   = cfg => http.get('/tariffs', cfg).then(r => r.data)
 const update = (rate, payload, cfg={}) =>
   http.put(`/tariffs/${rate}`, payload, cfg).then(r => r.data)
 
-export default { list, update }
+/** Consulta precio/minutos + clasificación WEEKEND/HOLIDAY/REGULAR */
+const preview = (date, rate, cfg = {}) =>
+  http.get('/tariffs/preview', { params: { date, rate }, ...cfg })
+      .then(r => r.data)
+
+export default { list, update, preview }


### PR DESCRIPTION
## Summary
- add preview endpoint method in tariff service
- show tariff preview on the reservation form
- include specialDay in reservation payload and handle API errors
- expose `useApiErrorHandler` helper

## Testing
- `npm run lint`
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bd18a1b4832c883116394edd11ed