### PR TITLE
Implement special day validation and update front-end

### DIFF
--- a/kartingrm-frontend/src/pages/PaymentPage.jsx
+++ b/kartingrm-frontend/src/pages/PaymentPage.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { Paper, Typography, Button, Stack, CircularProgress } from '@mui/material'
 import paymentService from '../services/payment.service'
-import { useNotify } from '../hooks/useNotify'
+import { useNotify, useApiErrorHandler } from '../hooks/useNotify'
 
 export default function PaymentPage() {
   const { reservationId } = useParams()
@@ -10,6 +10,7 @@ export default function PaymentPage() {
   const [loading, setLoading] = useState(false)
   const navigate          = useNavigate()
   const notify            = useNotify()
+  const handleError       = useApiErrorHandler()
 
   const handlePay = async () => {
     setLoading(true)
@@ -24,7 +25,7 @@ export default function PaymentPage() {
       setPaid(true)
       notify('Pago realizado ✅','success')
     } catch (e) {
-      notify(e.response?.data?.message || e.message, 'error')
+      handleError(e)
     } finally {
       setLoading(false)
     }

--- a/kartingrm-frontend/src/pages/ReservationsList.jsx
+++ b/kartingrm-frontend/src/pages/ReservationsList.jsx
@@ -6,7 +6,7 @@ import {
   Paper, Button, Stack, Typography, CircularProgress, Box
 } from '@mui/material'
 import reservationService from '../services/reservation.service'
-import { useNotify } from '../hooks/useNotify'
+import { useNotify, useApiErrorHandler } from '../hooks/useNotify'
 import ConfirmDialog from '../components/ConfirmDialog'
 
 export default function ReservationsList() {
@@ -15,6 +15,7 @@ export default function ReservationsList() {
   const [confirm, setConfirm] = useState({ open: false, id: null })
   const navigate = useNavigate()
   const notify = useNotify()
+  const handleError = useApiErrorHandler()
 
   /* carga con AbortController */
   useEffect(() => {
@@ -23,7 +24,7 @@ export default function ReservationsList() {
     reservationService.list({ signal: controller.signal })
       .then(r => setList(r.data))
       .catch(err => {
-        if (!controller.signal.aborted) console.error(err)
+        if (!controller.signal.aborted) handleError(err)
       })
       .finally(() => setLoading(false))
 
@@ -43,7 +44,7 @@ export default function ReservationsList() {
         reload()
         notify('Reserva cancelada', 'success')
       })
-      .catch(err => notify(err.response?.data?.message || err.message, 'error'))
+      .catch(err => handleError(err))
       .finally(() => setConfirm({ open: false, id: null }))
   }
 

--- a/kartingrm-frontend/src/pages/WeeklyRack.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRack.jsx
@@ -104,29 +104,19 @@ export default function WeeklyRack({ onCellClickAdmin }) {
 
                   if (!ses) return <TableCell key={DOW_ES[index] + range}></TableCell>
 
-                  const isOccupied = ses.participantsCount > 0;
+                  const isFull = ses.participantsCount >= ses.capacity
                   const label   = `${ses.participantsCount}/${ses.capacity}`
-                                  
+
                   return (
-                    <TableCell key={DOW_ES[index] + range} sx={{ p:0 }}>
-                      <Tooltip title={isOccupied ? `Ocupado ${label}` : `Disponible ${label}`}>
-                        <Box
-                          sx={{
-                            bgcolor: isOccupied ? 'error.main' : 'transparent',
-                            color:  isOccupied ? '#fff' : 'inherit',
-                            py: .5,
-                            cursor: isOccupied ? 'not-allowed':'pointer',
-                            textAlign:'center',
-                            '&:hover': { 
-                                opacity: isOccupied ? 1 : 0.8,
-                                backgroundColor: isOccupied ? 'error.main' : 'success.dark'
-                            }
-                          }}
-                          onClick={()=>!isOccupied && handleCellClick(ses)}
-                        >
-                          {label}
-                        </Box>
-                      </Tooltip>
+                    <TableCell
+                      key={DOW_ES[index] + range}
+                      sx={{ bgcolor: isFull ? 'error.main' : undefined,
+                            color:  isFull ? '#fff' : 'inherit',
+                            textAlign:'center', cursor:'pointer',
+                            pointerEvents: isFull ? 'none' : 'auto' }}
+                      onClick={()=>!isFull && handleCellClick(ses)}
+                    >
+                      {label}
                     </TableCell>
                   )
                 })}

--- a/kartingrm/src/main/java/com/kartingrm/dto/ReservationRequestDTO.java
+++ b/kartingrm/src/main/java/com/kartingrm/dto/ReservationRequestDTO.java
@@ -56,16 +56,12 @@ public record ReservationRequestDTO(
 
     public SpecialDay specialDay(){ return specialDay; }
 
-    /* coherencia weekend / holiday */
-    @AssertTrue(message = "SpecialDay no coincide con la fecha")
-    public boolean isSpecialDayConsistent(){
-        if (specialDay == null) return true;               // retro-compatibilidad
+    /* coherencia weekend / holiday --> se valida en ReservationService   */
+    @AssertTrue(message = "specialDay no puede ser REGULAR en fin de semana")
+    public boolean notRegularOnWeekend(){
+        if (specialDay == null) return true;
         boolean weekend = sessionDate.getDayOfWeek()==DayOfWeek.SATURDAY
                        || sessionDate.getDayOfWeek()==DayOfWeek.SUNDAY;
-        boolean holiday = false; // ⇒ usar HolidayService en Service layer
-        SpecialDay real = holiday ? SpecialDay.HOLIDAY :
-                         weekend ? SpecialDay.WEEKEND :
-                                   SpecialDay.REGULAR;
-        return real == specialDay;
+        return !(weekend && specialDay == SpecialDay.REGULAR);
     }
 }

--- a/kartingrm/src/test/java/com/kartingrm/service/ReservationServiceTest.java
+++ b/kartingrm/src/test/java/com/kartingrm/service/ReservationServiceTest.java
@@ -106,4 +106,18 @@ class ReservationServiceTest {
         assertThat(r1.getReservationCode())
                 .isNotEqualTo(r2.getReservationCode());
     }
+
+    @Test
+    void specialDayMismatch_throws(){
+       ReservationRequestDTO bad = new ReservationRequestDTO(
+           "X", c.getId(),
+           LocalDate.of(2025, 9, 18), // feriado
+           LocalTime.of(15,0), LocalTime.of(15,30),
+           List.of(new ParticipantDTO("P","p@p",false)),
+           com.kartingrm.entity.SpecialDay.REGULAR,
+           RateType.LAP_10);
+       assertThatThrownBy(() -> svc.createReservation(bad))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessageContaining("SpecialDay");
+    }
 }


### PR DESCRIPTION
## Summary
- validate specialDay in backend with TariffService
- preview tariff data in ReservationForm and block full slots in WeeklyRack
- handle API errors via useApiErrorHandler in PaymentPage and ReservationsList
- add regression test for special day mismatch

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869bf36cb90832c8a770ab51cdbd239