### PR TITLE
Address minor validation tweak

### DIFF
--- a/kartingrm/src/main/java/com/kartingrm/controller/advice/RestExceptionHandler.java
+++ b/kartingrm/src/main/java/com/kartingrm/controller/advice/RestExceptionHandler.java
@@ -20,7 +20,9 @@ public class RestExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex){
         boolean sd = ex.getFieldErrors().stream()
-                .anyMatch(f -> f.getDefaultMessage().contains("SpecialDay"));
+                .anyMatch(f -> f.getDefaultMessage()
+                        .toLowerCase()
+                        .contains("specialday"));
         return ResponseEntity.badRequest()
                 .body(new ApiError(sd ? "SPECIAL_DAY_MISMATCH" : "BAD_REQUEST",
                         ex.getFieldErrors().get(0).getDefaultMessage()));


### PR DESCRIPTION
## Summary
- fix specialDay validation check in `RestExceptionHandler`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6869c23eab64832ca039f4434bec30d3