### PR TITLE
Implement special day validation, CORS and preview fixes

### DIFF
--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -117,12 +117,11 @@ export default function ReservationForm({ edit = false }){
   })
 
   const notify = useNotify()
-  const apiError = useApiErrorHandler()
+  const handleError = useApiErrorHandler()
   const [toast,setToast] = useState({open:false,msg:'',severity:'success'})
 
   /*  Pre-cálculo de tarifa y tipo de día  */
-  const [tariffInfo, setTariffInfo] =
-        useState({ price: 0, minutes: 0, specialDay: 'REGULAR' })
+  const [preview, setPreview] = useState(null)
 
   /* ---- watchers útiles ---- */
   const sessionDate = watch('sessionDate')
@@ -135,8 +134,8 @@ export default function ReservationForm({ edit = false }){
     tariffSvc.preview(
         dayjs(sessionDate).format('YYYY-MM-DD'),
         rateType)
-      .then(setTariffInfo)
-      .catch(console.error)
+      .then(setPreview)
+      .catch(handleError)
   }, [sessionDate, rateType])
 
   /* ---------- mapas precio / duración ---------- */
@@ -213,7 +212,7 @@ export default function ReservationForm({ edit = false }){
         return
       }
 
-      const payload = { ...data, specialDay: tariffInfo.specialDay }
+      const payload = { ...data, specialDay: preview?.specialDay }
       const promise = edit ? reservationService.update(id, payload)
                            : reservationService.create(payload)
       const res = await promise
@@ -222,7 +221,7 @@ export default function ReservationForm({ edit = false }){
 
       navigate(`/payments/${res.id}`,{ replace:true })
     }catch(e){
-      apiError(e)
+      handleError(e)
     }
   }
 
@@ -311,10 +310,10 @@ export default function ReservationForm({ edit = false }){
 
           {/*  Muestra info devuelta por backend  */}
           <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
-            <Chip label={`$${tariffInfo.price.toLocaleString()}`} />
-            <Chip label={`${tariffInfo.minutes} min`} />
-            {tariffInfo.specialDay !== 'REGULAR' &&
-              <Chip color="warning" label={tariffInfo.specialDay} />}
+            <Chip label={`$${preview?.price?.toLocaleString() ?? 0}`} />
+            <Chip label={`${preview?.minutes ?? 0} min`} />
+            {preview?.specialDay && preview.specialDay !== 'REGULAR' &&
+              <Chip color="warning" label={preview.specialDay} />}
           </Stack>
 
           {/* ---------- hora fin ---------- */}

--- a/kartingrm/pom.xml
+++ b/kartingrm/pom.xml
@@ -58,12 +58,12 @@
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.36</version>
-			<scope>provided</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.30</version>
+                        <scope>provided</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -137,24 +137,25 @@
 			</resource>
 		</resources>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-							<version>1.18.36</version>
-						</path>
-						<path>
-							<groupId>org.mapstruct</groupId>
-							<artifactId>mapstruct-processor</artifactId>
-							<version>1.5.5.Final</version>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.11.0</version>
+                                <configuration>
+                                        <annotationProcessorPaths>
+                                                <path>
+                                                        <groupId>org.mapstruct</groupId>
+                                                        <artifactId>mapstruct-processor</artifactId>
+                                                        <version>1.5.5.Final</version>
+                                                </path>
+                                                <path>
+                                                        <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok</artifactId>
+                                                        <version>1.18.30</version>
+                                                </path>
+                                        </annotationProcessorPaths>
+                                </configuration>
+                        </plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/kartingrm/src/main/java/com/kartingrm/config/CorsConfig.java
+++ b/kartingrm/src/main/java/com/kartingrm/config/CorsConfig.java
@@ -1,0 +1,16 @@
+package com.kartingrm.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET","POST","PUT","PATCH","DELETE")
+                .allowedHeaders("*");
+    }
+}


### PR DESCRIPTION
## Summary
- add HolidayService validation in `ReservationService`
- configure CORS for `/api` endpoints
- update Lombok and MapStruct plugin config
- send `specialDay` from frontend preview
- disable full sessions in weekly rack

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869c39d2530832c9a5f380f7b97f708