### PR TITLE
Implement back-end validations and front improvements

### DIFF
--- a/kartingrm/pom.xml
+++ b/kartingrm/pom.xml
@@ -142,6 +142,8 @@
                                 <artifactId>maven-compiler-plugin</artifactId>
                                 <version>3.11.0</version>
                                 <configuration>
+                                        <source>17</source>
+                                        <target>17</target>
                                         <annotationProcessorPaths>
                                                 <path>
                                                         <groupId>org.mapstruct</groupId>

--- a/kartingrm/src/main/java/com/kartingrm/KartingrmApplication.java
+++ b/kartingrm/src/main/java/com/kartingrm/KartingrmApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableAsync
+@EnableCaching
 public class KartingrmApplication {
 
 	public static void main(String[] args) {

--- a/kartingrm/src/main/java/com/kartingrm/service/ReservationService.java
+++ b/kartingrm/src/main/java/com/kartingrm/service/ReservationService.java
@@ -141,19 +141,16 @@ public class ReservationService {
     }
 
     /* ---------------- helpers privados ------------------------------------ */
-
+    /* ---------- valida weekend / holiday ↔ SpecialDay ---------- */
     private void validateSpecialDay(ReservationRequestDTO dto) {
-        boolean weekend = dto.sessionDate().getDayOfWeek() == DayOfWeek.SATURDAY
-                        || dto.sessionDate().getDayOfWeek() == DayOfWeek.SUNDAY;
+        boolean weekend = dto.sessionDate().getDayOfWeek().getValue() >= 6;
         boolean holiday = holidayService.isHoliday(dto.sessionDate());
 
-        SpecialDay real = holiday ? SpecialDay.HOLIDAY
+        SpecialDay expected = holiday ? SpecialDay.HOLIDAY
                            : weekend ? SpecialDay.WEEKEND
                                      : SpecialDay.REGULAR;
-
-        if (dto.specialDay() == null || dto.specialDay() != real) {
-            throw new IllegalArgumentException(
-                    "SpecialDay mismatch – expected " + real);
+        if (dto.specialDay() == null || dto.specialDay() != expected) {
+            throw new IllegalArgumentException("SpecialDay mismatch – expected " + expected);
         }
     }
 

--- a/kartingrm/src/main/resources/application.properties
+++ b/kartingrm/src/main/resources/application.properties
@@ -19,8 +19,8 @@ kartingrm.default-session-capacity=15
 # SMTP (credenciales hardcodeadas)
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=nicolas.sanchez.al@usach.cl
-spring.mail.password=wkxpnwcczmfdhccx
+spring.mail.username=${SMTP_USER}
+spring.mail.password=${SMTP_PASS}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true

--- a/kartingrm/src/test/java/com/kartingrm/service/ReservationServiceTest.java
+++ b/kartingrm/src/test/java/com/kartingrm/service/ReservationServiceTest.java
@@ -120,4 +120,18 @@ class ReservationServiceTest {
               .isInstanceOf(IllegalArgumentException.class)
               .hasMessageContaining("SpecialDay");
     }
+
+    @Test
+    void specialDayValidation_ok_forWeekend() {
+        ReservationRequestDTO ok = new ReservationRequestDTO(
+                "OK", c.getId(),
+                LocalDate.of(2025, 9, 20), // sábado
+                LocalTime.of(15,0), LocalTime.of(15,30),
+                List.of(new ParticipantDTO("P","p@x.com",false)),
+                com.kartingrm.entity.SpecialDay.WEEKEND,
+                RateType.LAP_10);
+
+        assertThatCode(() -> svc.createReservation(ok))
+                .doesNotThrowAnyException();
+    }
 }


### PR DESCRIPTION
## Summary
- enable annotation processors with Java 17 in `maven-compiler-plugin`
- enable caching in Spring Boot application
- validate `SpecialDay` in reservations and add weekend test
- externalize SMTP credentials in properties

## Testing
- `./mvnw -q clean verify` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869c75a18a4832cb3684ecfb5571de9