### PR TITLE
Implement responsive weekly rack grid

### DIFF
--- a/kartingrm-frontend/package-lock.json
+++ b/kartingrm-frontend/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "^1.8.4",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
+        "framer-motion": "^12.23.0",
         "notistack": "^3.0.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3092,6 +3093,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.0.tgz",
+      "integrity": "sha512-xf6NxTGAyf7zR4r2KlnhFmsRfKIbjqeBupEDBAaEtVIBJX96sAon00kMlsKButSIRwPSHjbRrAPnYdJJ9kyhbA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.22.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3558,6 +3586,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.22.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
+      "integrity": "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4191,6 +4234,12 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/kartingrm-frontend/package.json
+++ b/kartingrm-frontend/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.8.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
+    "framer-motion": "^12.23.0",
     "notistack": "^3.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/kartingrm-frontend/src/pages/WeeklyRack.css
+++ b/kartingrm-frontend/src/pages/WeeklyRack.css
@@ -1,0 +1,45 @@
+/* Grid 7×N */
+.rack{
+  display:grid;
+  grid-template-columns: 60px repeat(7, 1fr);
+  /* 24 filas + encabezado, se expande automáticamente   */
+}
+
+.header{
+  font-weight:600;
+  text-align:center;
+  padding:4px 0;
+  background:#fafafa;
+  border:1px solid #e0e0e0;
+}
+
+.row{ display:contents; }               /* permite que cada hora comparta grid-row */
+
+.cell{
+  height:28px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border:1px solid #e0e0e0;
+  font-size:.75rem;
+  user-select:none;
+}
+
+/* Colores */
+.free { background:#C8E6C9;  cursor:pointer; }  /* green-100 */
+.free:hover{ background:#A5D6A7; }
+
+.busy { background:#E0E0E0; }                   /* grey-300 */
+.busy:hover{ background:#E0E0E0; }
+
+/* leyenda opcional al pie */
+.legend{
+  margin-top:8px;
+  display:flex; gap:16px;
+}
+.legend span{ display:flex; align-items:center; gap:4px; }
+.legend i{
+  width:18px; height:18px; display:inline-block; border:1px solid #ccc;
+}
+.legend .free i{ background:#C8E6C9; }
+.legend .busy i{ background:#E0E0E0;}


### PR DESCRIPTION
## Summary
- rewrite `WeeklyRack` with CSS Grid and framer-motion hover animations
- add accompanying stylesheet for the rack grid
- install `framer-motion` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6869fb68e760832c9ff1b848d9449a50