### PR TITLE
Improve weekly rack availability display

### DIFF
--- a/kartingrm-frontend/src/pages/WeeklyRack.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRack.jsx
@@ -107,23 +107,24 @@ export default function WeeklyRack({ onCellClickAdmin }) {
                 {DOW_EN.map((dayKey, index) => {
                   const ses = rack?.[dayKey]?.find(s=>s.startTime === start)
 
-                  if (!ses) return <TableCell key={DOW_ES[index] + range}></TableCell>
-
-                  const label   = `${ses.participantsCount}/${ses.capacity}`
-                  const full    = ses.participantsCount >= ses.capacity
+                  if (!ses) {
+                    return (
+                      <TableCell
+                        key={DOW_ES[index] + range}
+                        sx={{ bgcolor: 'success.light', textAlign:'center' }}
+                      >
+                        Disponible
+                      </TableCell>
+                    )
+                  }
 
                   return (
                     <TableCell
                       key={DOW_ES[index] + range}
-                      sx={{
-                        p: 1,
-                        bgcolor: full ? 'error.main' : 'success.light',
-                        textAlign: 'center',
-                        cursor: full ? 'default' : 'pointer'
-                      }}
-                      onClick={() => !full && handleCellClick(ses)}
+                      sx={{ bgcolor: 'error.main', textAlign: 'center' }}
+                      onClick={() => handleCellClick(ses)}
                     >
-                      {label}
+                      Ocupado
                     </TableCell>
                   )
                 })}


### PR DESCRIPTION
## Summary
- highlight free slots in green with 'Disponible'
- show occupied sessions in red with 'Ocupado'

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a0c046ed0832cb7969e3cfef2bc9b