### PR TITLE
Simplify weekly rack implementation

### DIFF
--- a/kartingrm-frontend/src/pages/WeeklyRack.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRack.jsx
@@ -1,130 +1,60 @@
 // src/pages/WeeklyRack.jsx
-import React, { useMemo } from 'react'
-import {
-  Table, TableHead, TableBody, TableRow, TableCell,
-  Paper, Typography, Tooltip, Box, Alert, CircularProgress, Stack
-} from '@mui/material'
-import { useQuery } from '@tanstack/react-query'
+import React, { useState, useEffect } from 'react'
+import { Table, TableHead, TableBody, TableRow, TableCell, Paper, CircularProgress } from '@mui/material'
 import dayjs from 'dayjs'
-import sessionSvc from '../services/session.service'
 import { useNavigate } from 'react-router-dom'
-import { useApiErrorHandler } from '../hooks/useNotify'
+import sessionSvc from '../services/session.service'
 
-const DOW_EN = ['MONDAY','TUESDAY','WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY']
-const DOW_ES = ['LUNES','MARTES','MIÉRCOLES','JUEVES','VIERNES','SÁBADO','DOMINGO']
+const DOW_EN = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY']
+const DOW_ES = ['LUN', 'MAR', 'MIÉ', 'JUE', 'VIE', 'SÁB', 'DOM']
 
-const Legend = () => (
-  <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
-    <Stack direction="row" alignItems="center" spacing={1}>
-      <Box sx={{ width: 16, height: 16, bgcolor: 'success.light', borderRadius: 1 }} />
-      <Typography variant="caption">Disponible</Typography>
-    </Stack>
-    <Stack direction="row" alignItems="center" spacing={1}>
-      <Box sx={{ width: 16, height: 16, bgcolor: 'error.main', borderRadius: 1 }} />
-      <Typography variant="caption">Ocupado</Typography>
-    </Stack>
-  </Stack>
-)
-
-export default function WeeklyRack({ onCellClickAdmin }) {
+export default function WeeklyRack() {
   const navigate = useNavigate()
-  const handleError = useApiErrorHandler()
+  const [rack, setRack] = useState(null)
 
-  const monday = dayjs().startOf('week').add(1, 'day')
-  const from   = monday.format('YYYY-MM-DD')
-  const to     = monday.add(6, 'day').format('YYYY-MM-DD')
+  useEffect(() => {
+    const monday = dayjs().startOf('week').add(1, 'day')
+    const from = monday.format('YYYY-MM-DD')
+    const to = monday.add(6, 'day').format('YYYY-MM-DD')
+    sessionSvc.weekly(from, to).then(r => setRack(r.data ?? {}))
+  }, [])
 
-  const fetchRack = () =>
-    sessionSvc.weekly(from, to)
-      .then(r => r.data ?? {})
-      .catch(handleError)
-
-
-  const { data: rack = {}, isPending, refetch: _refetch } = useQuery({
-    queryKey: ['rack', from, to],
-    queryFn: fetchRack,
-    staleTime: 5 * 60_000
-  })
-
-
-  /* ---------- todos los rangos HH:MM-HH:MM existentes ---------- */
-  const slots = useMemo(() => {
-    if (!rack || !Object.keys(rack).length) return []        // <= guarda
-    return Array.from(
-      new Set(
-        Object.values(rack)
-          .flat()
-          .map(s => `${s.startTime}-${s.endTime}`)
-      )
-    ).sort((a,b)=>a.localeCompare(b))
-  }, [rack])
-
-  const handleCellClick = (ses) => {
-    if (!ses) return
-    if (onCellClickAdmin) {
-      onCellClickAdmin(ses.sessionDate, ses.startTime, ses.endTime)
-      return
-    }
-    navigate(`/reservations/new?d=${ses.sessionDate}&s=${ses.startTime}&e=${ses.endTime}`)
+  if (!rack) {
+    return <CircularProgress sx={{ display: 'block', mx: 'auto', my: 4 }} />
   }
 
-  /* ---------- JSX ---------- */
-  if (isPending) {
-    return <CircularProgress sx={{ display:'block', mx:'auto', my:4 }}/>
-  }
+  const ranges = Array.from(new Set(
+    Object.values(rack).flat().map(s => `${s.startTime}-${s.endTime}`)
+  )).sort()
 
   return (
-    <Paper sx={{ p:2, overflowX:'auto' }}>
-      <Legend />
-      <Alert severity="info" sx={{ mb:2 }}>
-        Horario de Atención:
-        <strong> Lunes–Viernes 14:00–22:00</strong> |
-        <strong> Sábados, Domingos y Feriados 10:00–22:00</strong>
-      </Alert>
-      <Typography variant="h5" gutterBottom>
-        Disponibilidad (semana {from})
-      </Typography>
-
+    <Paper sx={{ p: 2, overflowX: 'auto' }}>
       <Table size="small">
         <TableHead>
           <TableRow>
-            <TableCell sx={{ fontWeight:'bold' }}>Hora</TableCell>
-            {DOW_ES.map(d=>(
-              <TableCell key={d} sx={{ fontWeight:'bold', textAlign:'center' }}>
-                {d.slice(0,3)}
-              </TableCell>
+            <TableCell>Hora</TableCell>
+            {DOW_ES.map(d => (
+              <TableCell key={d} align="center">{d}</TableCell>
             ))}
           </TableRow>
         </TableHead>
-
         <TableBody>
-          {slots.map(range => {
-            const [start,_end] = range.split('-')
+          {ranges.map(range => {
+            const start = range.split('-')[0]
             return (
               <TableRow key={range}>
                 <TableCell sx={{ fontWeight: 500 }}>{range}</TableCell>
-
-                {DOW_EN.map((dayKey, index) => {
-                  const ses = rack?.[dayKey]?.find(s=>s.startTime === start)
-
-                  if (!ses) {
-                    return (
-                      <TableCell
-                        key={DOW_ES[index] + range}
-                        sx={{ bgcolor: 'success.light', textAlign:'center' }}
-                      >
-                        Disponible
-                      </TableCell>
-                    )
-                  }
-
+                {DOW_EN.map(dayKey => {
+                  const ses = rack[dayKey]?.find(s => s.startTime === start)
+                  if (!ses) return <TableCell key={dayKey}></TableCell>
+                  const free = ses.participantsCount < ses.capacity
                   return (
                     <TableCell
-                      key={DOW_ES[index] + range}
-                      sx={{ bgcolor: 'error.main', textAlign: 'center' }}
-                      onClick={() => handleCellClick(ses)}
+                      key={dayKey}
+                      sx={{ bgcolor: free ? 'success.light' : 'error.main', textAlign: 'center', cursor: free ? 'pointer' : 'default' }}
+                      onClick={() => free && navigate(`/reservations/new?d=${ses.sessionDate}&s=${ses.startTime}&e=${ses.endTime}`)}
                     >
-                      Ocupado
+                      {free ? 'Disponible' : 'Ocupado'}
                     </TableCell>
                   )
                 })}


### PR DESCRIPTION
## Summary
- refactor WeeklyRack page to use basic hooks
- show a simple availability table

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_686a0ece2fd4832cb0153c5b44810fad