### PR TITLE
Fix remaining frontend issues

### DIFF
--- a/kartingrm-frontend/src/hooks/useApiErrorHandler.jsx
+++ b/kartingrm-frontend/src/hooks/useApiErrorHandler.jsx
@@ -7,15 +7,14 @@ import { useNotify } from './useNotify'
  */
 export const useApiErrorHandler = () => {
   const notify = useNotify()
-
-  return (err) => {
+  return err => {
     const msg =
-      err?.response?.data?.message ??
-      err?.response?.data?.error   ??
+      err?.response?.data?.message ||
+      err?.response?.data?.error ||
       err.message
 
-    /* Ejemplo de personalización */
-    if (/capacidad|overlap/i.test(msg)) {
+    // mapea mensajes conocidos
+    if (/Capacidad|Overlap/i.test(msg)) {
       notify('Capacidad de la sesión superada', 'error')
     } else {
       notify(msg, 'error')

--- a/kartingrm-frontend/src/pages/WeeklyRack.jsx
+++ b/kartingrm-frontend/src/pages/WeeklyRack.jsx
@@ -60,23 +60,17 @@ export default function WeeklyRack({ onCellClickAdmin }) {
 
   const handleCellClick = ses => {
     if (!ses) return
-
-    /* modo administrador */
+    // modo admin (editar sesión)
     if (onCellClickAdmin) {
       onCellClickAdmin(ses.sessionDate, ses.startTime, ses.endTime)
       return
     }
-
-    /* modo estándar: abre detalle si está llena, o formulario si hay cupos */
-    const isFull = ses.participantsCount >= ses.capacity
-    if (isFull) {
-      setSel(ses.id)
-    } else {
-      navigate(
-        `/reservations/new?d=${ses.sessionDate}` +
-        `&s=${ses.startTime}&e=${ses.endTime}`
-      )
-    }
+    const full = ses.participantsCount === ses.capacity
+    full
+      ? setSel(ses.id) // mostrar detalles
+      : navigate(
+          `/reservations/new?d=${ses.sessionDate}&s=${ses.startTime}&e=${ses.endTime}`
+        )
   }
 
   const rangeLabel =
@@ -84,8 +78,7 @@ export default function WeeklyRack({ onCellClickAdmin }) {
 
   /* ------------------- JSX ------------------------------ */
   return (
-    <>
-      <Paper sx={{ p: 2, overflowX: 'auto' }}>
+    <Paper sx={{ p: 2, overflowX: 'auto' }}>
         <Alert severity="info" sx={{ mb: 2 }}>
           Horario de Atención:
           <strong> Lunes–Viernes 14:00–22:00</strong> | 
@@ -152,13 +145,11 @@ export default function WeeklyRack({ onCellClickAdmin }) {
             })}
           </TableBody>
         </Table>
+        <ReservationDetailsDialog
+          id={sel}
+          open={!!sel}
+          onClose={() => setSel(null)}
+        />
       </Paper>
-
-      <ReservationDetailsDialog
-        id={sel}
-        open={Boolean(sel)}
-        onClose={() => setSel(null)}
-      />
-    </>
   )
 }


### PR DESCRIPTION
## Summary
- handle free-slot clicks properly in WeeklyRack
- show calendar route in NotFound component
- centralize API error handling
- use date picker in reservation form and enforce better validation

## Testing
- `npm run dev`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686b27cac4d8832cb9c8b5a9a1be428d