### PR TITLE
Fix CORS and update MUI pickers

### DIFF
--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -2,17 +2,13 @@
 import axios from 'axios'
 
 /* ──────────────────────────────────────────────────────────
-   Construimos baseURL así:
+   Base URL para Axios
 
-   • Si hay VITE_BACKEND_API_URL (= raíz del backend), añadimos /api
-       Ej.: http://localhost:8080  →  http://localhost:8080/api
-   • Si NO hay variable, asumimos que el front llamará a /api
-     y Vite lo proxy-eará a http://localhost:8080 (dev).
+   Si se define VITE_BACKEND_API_URL usaremos esa ruta como
+   raíz absoluta. De lo contrario asumimos que las llamadas
+   serán relativas y Vite las proxy‑eará durante el desarrollo.
 ─────────────────────────────────────────────────────────── */
-const root = import.meta.env.VITE_BACKEND_API_URL          // puede ser undefined
-const baseURL = root
-  ? `${root.replace(/\/+$/, '')}/api`
-  : '/api'
+const baseURL = import.meta.env.VITE_BACKEND_API_URL || ''
 
 const http = axios.create({
   baseURL,

--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -137,8 +137,10 @@ export default function ReservationForm ({ edit = false }) {
     if (!sessionDate || !rateType) return
     tariffSvc.preview(fmtDate(sessionDate), rateType)
       .then(p => {
-        setPreview(p)
-        setMinutes(p.minutes)          // dur. para efecto #3
+        if (preview?.minutes !== p.minutes) {
+          setPreview(p)
+          setMinutes(p.minutes)        // dur. para efecto #3
+        }
       })
       .catch(handleError)
   }, [sessionDate, rateType, handleError])
@@ -259,17 +261,20 @@ export default function ReservationForm ({ edit = false }) {
             <Controller
               name="sessionDate" control={control}
               render={({ field }) => (
-                <DesktopDatePicker
-                  label="Fecha"
-                  inputFormat="YYYY-MM-DD"
-                  value={dayjs(field.value)}
-                  onChange={val => field.onChange(val ? val.toDate() : null)}
-                  minDate={dayjs()}
-                  renderInput={params =>
-                    <TextField {...params}
-                               error={!!errors.sessionDate}
-                               helperText={errors.sessionDate?.message}/>}
-                />
+                  <DesktopDatePicker
+                    label="Fecha"
+                    inputFormat="YYYY-MM-DD"
+                    value={dayjs(field.value)}
+                    onChange={val => field.onChange(val ? val.toDate() : null)}
+                    minDate={dayjs()}
+                    slots={{ textField: TextField }}
+                    slotProps={{
+                      textField: {
+                        error: !!errors.sessionDate,
+                        helperText: errors.sessionDate?.message
+                      }
+                    }}
+                  />
               )}
             />
 
@@ -277,20 +282,23 @@ export default function ReservationForm ({ edit = false }) {
             <Controller
               name="startTime" control={control}
               render={({ field }) => (
-                <TimePicker
-                  label="Hora inicio"
-                  minTime={dayjs(minStart, 'HH:mm')}
-                  maxTime={dayjs(maxEnd,   'HH:mm')}
-                  value={field.value ? dayjs(field.value, 'HH:mm') : null}
-                  onChange={val => {
-                    const t = val ? val.format('HH:mm') : ''
-                    field.onChange(t)
-                  }}
-                  renderInput={params =>
-                    <TextField {...params}
-                               error={!!errors.startTime}
-                               helperText={errors.startTime?.message}/>}
-                />
+                  <TimePicker
+                    label="Hora inicio"
+                    minTime={dayjs(minStart, 'HH:mm')}
+                    maxTime={dayjs(maxEnd,   'HH:mm')}
+                    value={field.value ? dayjs(field.value, 'HH:mm') : null}
+                    onChange={val => {
+                      const t = val ? val.format('HH:mm') : ''
+                      field.onChange(t)
+                    }}
+                    slots={{ textField: TextField }}
+                    slotProps={{
+                      textField: {
+                        error: !!errors.startTime,
+                        helperText: errors.startTime?.message
+                      }
+                    }}
+                  />
               )}
             />
 
@@ -319,17 +327,20 @@ export default function ReservationForm ({ edit = false }) {
             <Controller
               name="endTime" control={control}
               render={({ field }) => (
-                <TimePicker
-                  label="Hora fin"
-                  minTime={dayjs(minStart, 'HH:mm')}
-                  maxTime={dayjs(maxEnd,   'HH:mm')}
-                  value={field.value ? dayjs(field.value, 'HH:mm') : null}
-                  readOnly disabled
-                  renderInput={params =>
-                    <TextField {...params}
-                               error={!!errors.endTime}
-                               helperText={errors.endTime?.message}/>}
-                />
+                  <TimePicker
+                    label="Hora fin"
+                    minTime={dayjs(minStart, 'HH:mm')}
+                    maxTime={dayjs(maxEnd,   'HH:mm')}
+                    value={field.value ? dayjs(field.value, 'HH:mm') : null}
+                    readOnly disabled
+                    slots={{ textField: TextField }}
+                    slotProps={{
+                      textField: {
+                        error: !!errors.endTime,
+                        helperText: errors.endTime?.message
+                      }
+                    }}
+                  />
               )}
             />
 

--- a/kartingrm-frontend/src/services/client.service.js
+++ b/kartingrm-frontend/src/services/client.service.js
@@ -3,10 +3,10 @@ import http from '../http-common'
 /**
  *  Todos los métodos aceptan un objeto opcional (signal, headers, …)
  */
-const getAll = (cfg = {})         => http.get('/clients',        cfg)
-const get    = (id, cfg = {})     => http.get(`/clients/${id}`,   cfg)
-const create = (payload, cfg = {})=> http.post('/clients', payload, cfg).then(r => r.data)
+const getAll = (cfg = {})         => http.get('/api/clients',        cfg)
+const get    = (id, cfg = {})     => http.get(`/api/clients/${id}`,   cfg)
+const create = (payload, cfg = {})=> http.post('/api/clients', payload, cfg).then(r => r.data)
 const update = (id, payload, cfg={}) =>
-  http.put(`/clients/${id}`, payload, cfg).then(r => r.data)
+  http.put(`/api/clients/${id}`, payload, cfg).then(r => r.data)
 
 export default { getAll, get, create, update }

--- a/kartingrm-frontend/src/services/payment.service.js
+++ b/kartingrm-frontend/src/services/payment.service.js
@@ -1,6 +1,6 @@
 import http from '../http-common'
-const pay = payload => http.post('/payments', payload)
-const receipt = id => http.get(`/payments/${id}/receipt`, {
+const pay = payload => http.post('/api/payments', payload)
+const receipt = id => http.get(`/api/payments/${id}/receipt`, {
   responseType:'blob',
   headers:{ Accept:'application/pdf' }
 })

--- a/kartingrm-frontend/src/services/report.service.js
+++ b/kartingrm-frontend/src/services/report.service.js
@@ -1,6 +1,6 @@
 import http from '../http-common'
-const byRate  = (from,to) => http.get('/reports/by-rate',  {params:{from,to}})
-const byGroup = (from,to) => http.get('/reports/by-group', {params:{from,to}})
-const byRateMonthly  = (from,to) => http.get('/reports/by-rate/monthly',  { params:{ from, to } })
-const byGroupMonthly = (from,to) => http.get('/reports/by-group/monthly', { params:{ from, to } })
+const byRate  = (from,to) => http.get('/api/reports/by-rate',  {params:{from,to}})
+const byGroup = (from,to) => http.get('/api/reports/by-group', {params:{from,to}})
+const byRateMonthly  = (from,to) => http.get('/api/reports/by-rate/monthly',  { params:{ from, to } })
+const byGroupMonthly = (from,to) => http.get('/api/reports/by-group/monthly', { params:{ from, to } })
 export default { byRate, byGroup, byRateMonthly, byGroupMonthly }

--- a/kartingrm-frontend/src/services/reservation.service.js
+++ b/kartingrm-frontend/src/services/reservation.service.js
@@ -1,11 +1,11 @@
 import http from '../http-common'
 
-const list   = (cfg={}) => http.get('/reservations', cfg)
-const get    = id       => http.get(`/reservations/${id}`)
-const create = payload   => http.post('/reservations', payload).then(r => r.data)
-const update = (id,payload) => http.patch(`/reservations/${id}`, payload).then(r => r.data)
+const list   = (cfg={}) => http.get('/api/reservations', cfg)
+const get    = id       => http.get(`/api/reservations/${id}`)
+const create = payload   => http.post('/api/reservations', payload).then(r => r.data)
+const update = (id,payload) => http.patch(`/api/reservations/${id}`, payload).then(r => r.data)
 const remove = id =>
-  http.delete(`/reservations/${id}`).then(r => {
+  http.delete(`/api/reservations/${id}`).then(r => {
     window.dispatchEvent(new CustomEvent('availabilityUpdated'))
     return r
   })

--- a/kartingrm-frontend/src/services/session.service.js
+++ b/kartingrm-frontend/src/services/session.service.js
@@ -4,14 +4,14 @@ import dayjs from 'dayjs'
 const fmt = d => dayjs(d).format('YYYY-MM-DD')
 
 const weekly = (from, to, cfg = {}) =>
-  http.get('/sessions/availability', {
+  http.get('/api/sessions/availability', {
     params:{ from: fmt(from), to: fmt(to) },
     ...cfg
   })
 
-const getAll = (cfg = {})            => http.get('/sessions', cfg)
-const create = (payload, cfg = {})   => http.post('/sessions', payload, cfg).then(r => r.data)
-const update = (id, payload, cfg={}) => http.put(`/sessions/${id}`, payload, cfg).then(r => r.data)
-const remove = (id, cfg = {})        => http.delete(`/sessions/${id}`, cfg)
+const getAll = (cfg = {})            => http.get('/api/sessions', cfg)
+const create = (payload, cfg = {})   => http.post('/api/sessions', payload, cfg).then(r => r.data)
+const update = (id, payload, cfg={}) => http.put(`/api/sessions/${id}`, payload, cfg).then(r => r.data)
+const remove = (id, cfg = {})        => http.delete(`/api/sessions/${id}`, cfg)
 
 export default { weekly, getAll, create, update, delete: remove }

--- a/kartingrm-frontend/src/services/tariff.service.js
+++ b/kartingrm-frontend/src/services/tariff.service.js
@@ -2,13 +2,13 @@
 import http from '../http-common'
 import { fmtDate } from '../helpers' // 1º TODOS los imports
 
-const list   = cfg => http.get('/tariffs', cfg).then(r => r.data)
+const list   = cfg => http.get('/api/tariffs', cfg).then(r => r.data)
 const update = (rate, payload, cfg={}) =>
-  http.put(`/tariffs/${rate}`, payload, cfg).then(r => r.data)
+  http.put(`/api/tariffs/${rate}`, payload, cfg).then(r => r.data)
 
 /** Consulta precio/minutos + clasificación WEEKEND/HOLIDAY/REGULAR */
 const preview = (date, rate, cfg = {}) =>
-  http.get('/tariffs/preview', { params: { date: fmtDate(date), rate }, ...cfg })
+  http.get('/api/tariffs/preview', { params: { date: fmtDate(date), rate }, ...cfg })
       .then(r => r.data)
 
 export default { list, update, preview }

--- a/kartingrm-frontend/vite.config.js
+++ b/kartingrm-frontend/vite.config.js
@@ -5,17 +5,21 @@ import process from 'node:process'
 
 export default defineConfig({
   plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      // Todo lo que empiece con /api lo reenvía al backend
-      '/api': {
-        target: process.env.VITE_BACKEND_API_URL || 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false,
-        // Opcional: elimina el prefijo /api en destino
-        // rewrite: path => path               // <<— NO lo uses: tu backend sí expone /api
+    server: {
+      port: 5173,
+      proxy: {
+        // Todo lo que empiece con /api lo reenvía al backend
+        '/api': {
+          target: process.env.VITE_BACKEND_API_URL || 'http://localhost:8080',
+          changeOrigin: true,
+          secure: false
+        },
+        // Además reenviamos /sessions por compatibilidad
+        '/sessions': {
+          target: process.env.VITE_BACKEND_API_URL || 'http://localhost:8080',
+          changeOrigin: true,
+          secure: false
+        }
       }
     }
-  }
 })

--- a/kartingrm/src/main/java/com/kartingrm/config/CorsConfig.java
+++ b/kartingrm/src/main/java/com/kartingrm/config/CorsConfig.java
@@ -12,5 +12,11 @@ public class CorsConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET","POST","PUT","PATCH","DELETE")
                 .allowedHeaders("*");
+
+        // Permitir también las rutas sin prefijo /api utilizadas por legacy
+        registry.addMapping("/sessions/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET","POST","PUT","PATCH","DELETE")
+                .allowedHeaders("*");
     }
 }


### PR DESCRIPTION
## Summary
- use VITE_BACKEND_API_URL directly in axios base URL
- prefix API routes in all service modules
- proxy `/sessions` in Vite dev server
- adjust CORS mapping to allow `/sessions/**`
- migrate date pickers to MUI v6 slots API
- guard tariff preview effect to avoid loops

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./mvnw -q test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686b4a357c40832ca6fe3877f6531962