### PR TITLE
Expand README with Spanish section

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -7,6 +7,14 @@ Karting Final es un sistema de gestión de reservas para una pista de karts. El 
 
 El backend expone endpoints para gestionar clientes, karts, sesiones, reservas y pagos. También genera recibos PDF y varios informes de ingresos. El frontend consume estas APIs para ofrecer una interfaz de administración.
 
+## Características principales
+
+- Operaciones CRUD para karts, clientes y sesiones
+- Gestión de reservas con control de capacidad
+- Procesamiento de pagos y generación de recibos PDF
+- Informes de ingresos y métricas para Prometheus
+- Notificaciones por correo en las confirmaciones de reserva
+
 ---
 
 ## Estructura del repositorio
@@ -42,6 +50,11 @@ Cada módulo puede trabajarse de forma independiente como se explica a continuac
    mvn package
    java -jar target/kartingrm-0.0.1-SNAPSHOT.jar
    ```
+5. **Ejecutar pruebas**
+   ```bash
+   mvn test
+   ```
+   Las pruebas unitarias cubren la capa de servicios.
 
 ---
 
@@ -60,6 +73,7 @@ Cada módulo puede trabajarse de forma independiente como se explica a continuac
    npm run build
    ```
    El sitio estático se genera en `kartingrm-frontend/dist/` y puede servirse con cualquier servidor web.
+   Define `VITE_BACKEND_API_URL` durante la compilación si el backend se aloja en otra dirección.
 
 ---
 
@@ -67,5 +81,6 @@ Cada módulo puede trabajarse de forma independiente como se explica a continuac
 
 - Algunas funcionalidades envían notificaciones por correo electrónico. Las credenciales para la cuenta SMTP se leen de `src/main/resources/application.properties`. El directorio `secrets` puede usarse para almacenar valores sensibles localmente.
 - Las métricas se exponen mediante el actuador de Spring Boot y el registro de Prometheus.
+- El puerto del servidor y la capacidad por sesión pueden cambiarse con las variables de entorno `SERVER_PORT` y `KARTINGRM_DEFAULT_SESSION_CAPACITY`.
 
 Con ambos servicios en funcionamiento puedes gestionar reservas, monitorizar la disponibilidad de las sesiones y emitir pagos directamente desde la interfaz web.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Karting Final is a reservation management system for a go-kart track. The reposi
 
 The backend exposes endpoints for managing clients, karts, sessions, reservations and payments. It also generates PDF receipts and several income reports. The frontend consumes these APIs to provide an administration interface.
 
+## Key features
+
+- CRUD operations for karts, clients and sessions
+- Reservation management with capacity checks
+- Payment processing with PDF receipt generation
+- Income reports and Prometheus metrics
+- Email notifications when reservations are confirmed
+
 ---
 
 ## Repository layout
@@ -44,6 +52,11 @@ Each module can be worked on independently as described below.
    mvn package
    java -jar target/kartingrm-0.0.1-SNAPSHOT.jar
    ```
+5. **Running tests**
+   ```bash
+   mvn test
+   ```
+   Unit tests validate the service layer.
 
 ---
 
@@ -62,6 +75,7 @@ Each module can be worked on independently as described below.
    npm run build
    ```
    The static site is generated in `kartingrm-frontend/dist/` and can be served with any web server.
+   Set `VITE_BACKEND_API_URL` during build if the backend is hosted elsewhere.
 
 ---
 
@@ -69,5 +83,6 @@ Each module can be worked on independently as described below.
 
 - Some features send email notifications. Credentials for the SMTP account are read from `src/main/resources/application.properties`. The `secrets` directory can be used to store sensitive values locally.
 - Metrics are exposed through the Spring Boot actuator and Prometheus registry.
+- The server port and default session capacity can be changed using the environment variables `SERVER_PORT` and `KARTINGRM_DEFAULT_SESSION_CAPACITY`.
 
 With both services running you can manage reservations, monitor session availability and issue payments directly from the web UI.


### PR DESCRIPTION
## Summary
- add an expanded 'Key features' section to README
- add Spanish translations and instructions in `README.es.md`

## Testing
- `mvn test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b51d66100832c828563846566c61c